### PR TITLE
Publish one action as several tools, and automate NuGet releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore Nabu.NET.sln
+
+      - name: Build
+        run: dotnet build Nabu.NET.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Nabu.NET.sln --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
+
+      - name: Pack
+        run: dotnet pack src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj --configuration Release --no-build --output artifacts
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: artifacts/*
+          if-no-files-found: error
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: "**/TestResults/*.trx"
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+# Publishing is driven entirely by tags: push `v1.2.3` and that exact version is built, tested,
+# packed and pushed to nuget.org. The tag is the single source of truth for the package version,
+# so `VersionPrefix` in Directory.Build.props never has to be kept in sync by hand.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, without the leading v (for example 1.2.3)."
+        required: true
+        type: string
+      dry_run:
+        description: "Build and pack, but do not push to nuget.org."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  NUGET_SOURCE: https://api.nuget.org/v3/index.json
+
+jobs:
+  publish:
+    name: Pack and publish to NuGet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Resolve the version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            version="${TAG_NAME#v}"
+          fi
+
+          if ! printf '%s' "${version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'${version}' is not a valid package version. Tag releases as v<major>.<minor>.<patch>[-prerelease]." >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          case "${version}" in
+            *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+          echo "Publishing version ${version}."
+
+      - name: Restore
+        run: dotnet restore Nabu.NET.sln
+
+      - name: Build
+        run: >-
+          dotnet build Nabu.NET.sln
+          --configuration Release
+          --no-restore
+          -p:Version=${{ steps.version.outputs.version }}
+          -p:ContinuousIntegrationBuild=true
+
+      - name: Test
+        run: >-
+          dotnet test Nabu.NET.sln
+          --configuration Release
+          --no-build
+          -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Pack
+        run: >-
+          dotnet pack src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
+          --configuration Release
+          --no-build
+          --output artifacts
+          -p:Version=${{ steps.version.outputs.version }}
+          -p:ContinuousIntegrationBuild=true
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ steps.version.outputs.version }}
+          path: artifacts/*
+          if-no-files-found: error
+
+      - name: Push to NuGet
+        if: ${{ !inputs.dry_run }}
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NUGET_API_KEY}" ]; then
+            echo "::error::The NUGET_API_KEY repository secret is not set, so there is nothing to authenticate with." >&2
+            exit 1
+          fi
+
+          # The matching .snupkg is picked up automatically alongside each .nupkg.
+          dotnet nuget push "artifacts/*.nupkg" \
+            --api-key "${NUGET_API_KEY}" \
+            --source "${NUGET_SOURCE}" \
+            --skip-duplicate
+
+      - name: Create the GitHub release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh release create "${{ github.ref_name }}"
+          --title "${{ github.ref_name }}"
+          --generate-notes
+          ${{ steps.version.outputs.prerelease == 'true' && '--prerelease' || '' }}
+          artifacts/*

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,14 +7,28 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <Authors>Nabu.NET contributors</Authors>
+    <Authors>Hovik Aghajanyan</Authors>
+    <Company>Hovik Aghajanyan</Company>
     <Product>Nabu.NET</Product>
-    <Copyright>Copyright (c) Nabu.NET contributors</Copyright>
+    <Copyright>Copyright (c) Hovik Aghajanyan</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://aghajanyan.me</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hovik-aghajanyan/nabu.net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <VersionPrefix>1.0.0</VersionPrefix>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!--
+    Source Link: ships the repository coordinates and untracked sources in the symbol package so
+    consumers can step into the library. The .NET 8 SDK provides the GitHub provider in-box.
+  -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Nabu.NET contributors
+Copyright (c) 2026 Hovik Aghajanyan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Nabu.NET
 
+[![CI](https://github.com/hovik-aghajanyan/nabu.net/actions/workflows/ci.yml/badge.svg)](https://github.com/hovik-aghajanyan/nabu.net/actions/workflows/ci.yml)
+[![NuGet](https://img.shields.io/nuget/v/Nabu.Mcp.AspNetCore.svg)](https://www.nuget.org/packages/Nabu.Mcp.AspNetCore)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 **Expose the ASP.NET Core Web API you already have as MCP tools by adding one attribute.**
 
 `Nabu.Mcp.AspNetCore` turns existing controller actions into [Model Context Protocol](https://modelcontextprotocol.io)
@@ -21,6 +25,7 @@ public ActionResult<TodoItem> GetById(Guid id) => ...
 - [Why replay the pipeline](#why-replay-the-pipeline)
 - [Getting started](#getting-started)
 - [Attributes](#attributes)
+- [One action, several tools](#one-action-several-tools)
 - [How arguments are mapped](#how-arguments-are-mapped)
 - [Schema generation](#schema-generation)
 - [Authentication and authorization](#authentication-and-authorization)
@@ -29,6 +34,7 @@ public ActionResult<TodoItem> GetById(Guid id) => ...
 - [Target frameworks](#target-frameworks)
 - [Repository layout](#repository-layout)
 - [Building and testing](#building-and-testing)
+- [Releasing](#releasing)
 - [Limitations](#limitations)
 
 ---
@@ -137,7 +143,7 @@ curl -X POST http://localhost:5000/mcp \
 
 | Attribute | Target | Purpose |
 |---|---|---|
-| `[McpTool]` | action | Publishes the action as a tool. |
+| `[McpTool]` | action | Publishes the action as a tool. Repeatable - see [One action, several tools](#one-action-several-tools). |
 | `[McpTool]` | controller | Publishes every action on the controller. |
 | `[McpIgnore]` | controller, action, parameter, property | Excludes it. Always wins. |
 | `[McpParameter]` | parameter, property | Overrides the name, description, requiredness or example of one input. |
@@ -156,6 +162,72 @@ explicitly overrides that default.
     Destructive = true)]
 public IActionResult Publish(Guid id) => ...
 ```
+
+## One action, several tools
+
+A single endpoint is often the wrong shape for a model. `GET /api/todos` with five optional filters is
+easy for a client that already knows what it wants and awkward for a model that has to guess. Apply
+`[McpTool]` more than once and the same action is published as several tools, each with its own name,
+description and parameter set - without adding controller actions, and with the same pipeline replay
+behind every one of them.
+
+```csharp
+[HttpGet]
+[McpTool]                                                       // the full endpoint, unchanged
+[McpTool("todos_list_open",
+    Title = "List open todos",
+    Description = "Lists the todo items that are still open.",
+    ExcludeParameters = new[] { "search", "priority" },
+    ConstantParameters = new[] { "isCompleted=false" })]
+[McpTool("todos_search",
+    Title = "Search todos",
+    Description = "Searches the signed-in user's todo items by title and notes.",
+    IncludeParameters = new[] { "search", "page", "pageSize" },
+    RequiredParameters = new[] { "search" })]
+public ActionResult<TodoPage> List(
+    [FromQuery] bool? isCompleted,
+    [FromQuery] TodoPriority? priority,
+    [FromQuery] string? search,
+    [FromQuery] int page = 0,
+    [FromQuery] int pageSize = 20) => ...
+```
+
+`tools/list` now advertises three tools over one action: `todos_list` takes all five filters,
+`todos_list_open` takes only `page` and `pageSize` and can never return completed items, and
+`todos_search` takes a mandatory `search` plus paging.
+
+| Property | Effect |
+|---|---|
+| `IncludeParameters` | Whitelist. Only these inputs are exposed; everything else is left unset. |
+| `ExcludeParameters` | Hides inputs. They are left unset, so the action's own defaults apply. |
+| `ConstantParameters` | `name=value` pairs. The input disappears from the schema and the value is always sent. |
+| `RequiredParameters` | Marks inputs required for this tool even if the action treats them as optional. |
+| `OptionalParameters` | The reverse. Route tokens the URL cannot be built without stay required. |
+
+Notes:
+
+- Names match either the tool input name (camelCase, as it appears in the schema) or the underlying
+  binding name, case-insensitively. A name that matches nothing is logged as a warning.
+- Constant values are converted to the parameter's CLR type: `pageSize=100` becomes a JSON number,
+  `isCompleted=false` a JSON boolean, a complex parameter accepts a JSON literal such as
+  `tags=["docs","ops"]`, and everything else is sent as a string. On a non-string parameter an empty
+  value or `null` means "send nothing".
+- A constant always wins over an argument that happens to target the same place, so a pinned value
+  cannot be talked out of by the model.
+- Route tokens can be pinned too, which is how an endpoint collapses into a zero-argument tool:
+
+  ```csharp
+  [HttpGet("{city}")]
+  [McpTool]
+  [McpTool("weather_get_yerevan_week", ConstantParameters = new[] { "city=Yerevan", "days=7" })]
+  public ActionResult<IEnumerable<Forecast>> GetForecast(string city, [FromQuery] int days = 3) => ...
+  ```
+
+  Hiding a route token *without* pinning it would produce a tool whose URL cannot be built, so Nabu
+  logs a warning and skips that variant rather than publishing something uncallable.
+- Give every extra variant an explicit `Name`. Variants without one fall back to the generated
+  `controller_action` name and collide, and all but the first end up with a `_2`, `_3`, ... suffix.
+- Variants declared on an action replace a controller-wide `[McpTool]` rather than adding to it.
 
 ## How arguments are mapped
 
@@ -297,6 +369,7 @@ Newtonsoft.Json.
 src/Nabu.Mcp.AspNetCore/     the framework
 samples/Nabu.Sample.TodoApi/ a JWT-secured todo API wired up with Nabu
 tests/Nabu.Mcp.AspNetCore.Tests/  unit and integration tests
+.github/workflows/           CI on every push and PR, NuGet publishing on every v* tag
 ```
 
 The sample is a working API with JWT bearer authentication, a role-based policy, model validation and
@@ -312,13 +385,40 @@ dotnet run --project samples/Nabu.Sample.TodoApi
 
 ```bash
 dotnet build          # netstandard2.0 + net6.0 + net8.0
-dotnet test           # 149 tests
+dotnet test           # 180 tests
 ```
 
-The suite covers route template parsing, tool naming, JSON schema generation, argument binding and
-enum coercion as units, and drives the real sample application in memory for discovery, invocation,
-authorization and protocol behaviour - including that a tool call for one user never returns another
-user's data, and that an admin-only action stays admin-only when reached over MCP.
+The suite covers route template parsing, tool naming, JSON schema generation, argument binding,
+constant parsing and enum coercion as units, and drives the real sample application in memory for
+discovery, invocation, authorization and protocol behaviour - including that a tool call for one user
+never returns another user's data, and that an admin-only action stays admin-only when reached over
+MCP.
+
+Every push to `main` and every pull request runs the same build, test and pack on GitHub Actions
+(`.github/workflows/ci.yml`).
+
+## Releasing
+
+Publishing to [nuget.org](https://www.nuget.org/packages/Nabu.Mcp.AspNetCore) is driven by tags. The
+tag is the single source of truth for the package version, so `VersionPrefix` in
+`Directory.Build.props` never has to be kept in sync by hand.
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+`.github/workflows/release.yml` then restores, builds, tests, packs `Nabu.Mcp.AspNetCore` at `1.2.3`,
+pushes the `.nupkg` and its `.snupkg` symbol package to nuget.org, and opens a GitHub release with
+generated notes and the packages attached. A tag containing a hyphen (`v1.2.3-rc.1`) is published as a
+prerelease.
+
+One-time setup: add a nuget.org API key as the **`NUGET_API_KEY`** repository secret
+(*Settings → Secrets and variables → Actions*). Scope it to the `Nabu.Mcp.AspNetCore` package, or to
+`Nabu.*` with "Push new packages and package versions" if the package does not exist yet.
+
+The workflow can also be started manually from the Actions tab with an explicit version, and has a
+`dry_run` option that builds and packs without pushing anything.
 
 ## Limitations
 

--- a/samples/Nabu.Sample.TodoApi/Controllers/TodosController.cs
+++ b/samples/Nabu.Sample.TodoApi/Controllers/TodosController.cs
@@ -38,6 +38,18 @@ namespace Nabu.Sample.TodoApi.Controllers
         /// <param name="pageSize">Number of items per page, between 1 and 100.</param>
         [HttpGet]
         [McpTool]
+        [McpTool(
+            "todos_list_open",
+            Title = "List open todos",
+            Description = "Lists the todo items that are still open. Completed items are never returned.",
+            ExcludeParameters = new[] { "search", "priority" },
+            ConstantParameters = new[] { "isCompleted=false" })]
+        [McpTool(
+            "todos_search",
+            Title = "Search todos",
+            Description = "Searches the signed-in user's todo items by title and notes.",
+            IncludeParameters = new[] { "search", "page", "pageSize" },
+            RequiredParameters = new[] { "search" })]
         public ActionResult<TodoPage> List(
             [FromQuery] bool? isCompleted,
             [FromQuery] TodoPriority? priority,

--- a/samples/Nabu.Sample.TodoApi/Controllers/WeatherController.cs
+++ b/samples/Nabu.Sample.TodoApi/Controllers/WeatherController.cs
@@ -39,6 +39,12 @@ namespace Nabu.Sample.TodoApi.Controllers
         /// <param name="city">Name of the city to forecast.</param>
         /// <param name="days">How many days to forecast, from 1 to 14.</param>
         [HttpGet("{city}")]
+        [McpTool]
+        [McpTool(
+            "weather_get_yerevan_week",
+            Title = "Yerevan week ahead",
+            Description = "Returns the seven day forecast for Yerevan. Takes no arguments.",
+            ConstantParameters = new[] { "city=Yerevan", "days=7" })]
         public ActionResult<IEnumerable<Forecast>> GetForecast(
             string city,
             [FromQuery] [Range(1, 14)] int days = 3)

--- a/src/Nabu.Mcp.AspNetCore/Attributes/McpToolAttribute.cs
+++ b/src/Nabu.Mcp.AspNetCore/Attributes/McpToolAttribute.cs
@@ -7,11 +7,30 @@ namespace Nabu.Mcp.AspNetCore
     /// class - as a Model Context Protocol tool.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The action keeps behaving like a normal MVC action. Nabu does not call the method directly;
     /// it replays a synthetic HTTP request through the application pipeline, so filters,
     /// authentication, authorization, model binding and validation all still run.
+    /// </para>
+    /// <para>
+    /// The attribute may be applied several times to the same action. Each occurrence publishes a
+    /// separate tool over the same action, which is how one endpoint is exposed under several names
+    /// with different parameter sets - see <see cref="IncludeParameters"/>,
+    /// <see cref="ExcludeParameters"/> and <see cref="ConstantParameters"/>.
+    /// </para>
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    /// <example>
+    /// <code>
+    /// [HttpGet]
+    /// [McpTool("todos_search", Description = "Search todo items with the full filter set.")]
+    /// [McpTool("todos_list_overdue",
+    ///     Description = "List the overdue todo items.",
+    ///     ExcludeParameters = new[] { "search", "priority" },
+    ///     ConstantParameters = new[] { "isCompleted=false", "pageSize=100" })]
+    /// public ActionResult&lt;TodoPage&gt; List(bool? isCompleted, TodoPriority? priority, string? search, int page = 0, int pageSize = 20)
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public sealed class McpToolAttribute : Attribute
     {
         private bool? _readOnly;
@@ -49,6 +68,46 @@ namespace Nabu.Mcp.AspNetCore
         /// Useful for feature flags applied at build time.
         /// </summary>
         public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Restricts the tool to this set of inputs; everything else the action accepts is hidden and
+        /// left unset. <c>null</c> or empty means "expose every input", which is the default.
+        /// </summary>
+        /// <remarks>
+        /// Names match either the tool input name (camelCase, as it appears in the schema) or the
+        /// underlying binding name, case-insensitively. <see cref="ConstantParameters"/> entries are
+        /// applied regardless of this list.
+        /// </remarks>
+        public string[]? IncludeParameters { get; set; }
+
+        /// <summary>
+        /// Hides these inputs from the tool schema. They are left unset on the request, so the action's
+        /// own defaults apply. Applied after <see cref="IncludeParameters"/>.
+        /// </summary>
+        public string[]? ExcludeParameters { get; set; }
+
+        /// <summary>
+        /// Pins inputs to fixed values, in <c>name=value</c> form (for example
+        /// <c>"isCompleted=false"</c>). Pinned inputs disappear from the tool schema and the value is
+        /// always sent on the underlying request, so a single action can back several narrower tools.
+        /// </summary>
+        /// <remarks>
+        /// The value is converted to the parameter's CLR type: numbers and booleans become JSON
+        /// numbers and booleans, complex parameters accept a JSON literal, and everything else is sent
+        /// as a string. A bare name with no <c>=</c> pins the parameter to an empty string.
+        /// </remarks>
+        public string[]? ConstantParameters { get; set; }
+
+        /// <summary>
+        /// Marks these inputs as required for this tool even when the action treats them as optional.
+        /// </summary>
+        public string[]? RequiredParameters { get; set; }
+
+        /// <summary>
+        /// Marks these inputs as optional for this tool. Route tokens that the route template cannot
+        /// do without stay required regardless.
+        /// </summary>
+        public string[]? OptionalParameters { get; set; }
 
         /// <summary>
         /// <c>readOnlyHint</c> annotation. Defaults to <c>true</c> for GET/HEAD actions.

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpConstantValue.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpConstantValue.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Nabu.Mcp.AspNetCore.Schema;
+
+namespace Nabu.Mcp.AspNetCore.Discovery
+{
+    /// <summary>
+    /// Parses the <c>name=value</c> entries of <see cref="McpToolAttribute.ConstantParameters"/>.
+    /// Attribute arguments can only be compile-time constants, so values arrive as text and are
+    /// converted here to the JSON shape the target parameter expects.
+    /// </summary>
+    internal static class McpConstantValue
+    {
+        private static readonly HashSet<Type> IntegerTypes = new HashSet<Type>
+        {
+            typeof(byte), typeof(sbyte), typeof(short), typeof(ushort),
+            typeof(int), typeof(uint), typeof(long), typeof(ulong),
+        };
+
+        private static readonly HashSet<Type> DecimalTypes = new HashSet<Type>
+        {
+            typeof(float), typeof(double), typeof(decimal),
+        };
+
+        /// <summary>Splits <c>"name=value"</c>. A bare name yields an empty value.</summary>
+        public static bool TrySplit(string? entry, out string name, out string value)
+        {
+            name = string.Empty;
+            value = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(entry))
+            {
+                return false;
+            }
+
+            var separator = entry!.IndexOf('=');
+            if (separator < 0)
+            {
+                name = entry.Trim();
+                return name.Length > 0;
+            }
+
+            name = entry.Substring(0, separator).Trim();
+
+            // Everything after the first '=' is the value, verbatim: JSON literals and connection-string
+            // style values both contain '=' of their own.
+            value = entry.Substring(separator + 1);
+            return name.Length > 0;
+        }
+
+        /// <summary>Converts the textual constant to the JSON value the action's binder will accept.</summary>
+        public static JsonNode? Convert(string raw, Type type)
+        {
+            var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+            if (underlying == typeof(string))
+            {
+                return JsonValue.Create(raw);
+            }
+
+            var trimmed = raw.Trim();
+
+            if (trimmed.Length == 0)
+            {
+                // An empty value on a non-string parameter means "send nothing", not "send an empty string".
+                return null;
+            }
+
+            if (string.Equals(trimmed, "null", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (underlying == typeof(bool))
+            {
+                bool parsedBool;
+                if (bool.TryParse(trimmed, out parsedBool))
+                {
+                    return JsonValue.Create(parsedBool);
+                }
+
+                return JsonValue.Create(raw);
+            }
+
+            if (IntegerTypes.Contains(underlying))
+            {
+                long parsedLong;
+                if (long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedLong))
+                {
+                    return JsonValue.Create(parsedLong);
+                }
+
+                ulong parsedULong;
+                if (ulong.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedULong))
+                {
+                    return JsonValue.Create(parsedULong);
+                }
+
+                return JsonValue.Create(raw);
+            }
+
+            if (DecimalTypes.Contains(underlying))
+            {
+                decimal parsedDecimal;
+                if (decimal.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out parsedDecimal))
+                {
+                    return JsonValue.Create(parsedDecimal);
+                }
+
+                double parsedDouble;
+                if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out parsedDouble))
+                {
+                    return JsonValue.Create(parsedDouble);
+                }
+
+                return JsonValue.Create(raw);
+            }
+
+            // Enums stay textual: tool schemas describe them by name and JsonBodyCoercion converts the
+            // name to a number when the application's formatters expect numbers.
+            if (underlying.IsEnum)
+            {
+                return JsonValue.Create(raw);
+            }
+
+            if (JsonSchemaGenerator.IsComplexObject(underlying) ||
+                JsonSchemaGenerator.GetEnumerableElementType(underlying) != null)
+            {
+                JsonNode? parsed;
+                if (TryParseJson(trimmed, out parsed))
+                {
+                    return parsed;
+                }
+            }
+
+            return JsonValue.Create(raw);
+        }
+
+        private static bool TryParseJson(string text, out JsonNode? node)
+        {
+            node = null;
+
+            var first = text[0];
+            if (first != '{' && first != '[' && first != '"')
+            {
+                return false;
+            }
+
+            try
+            {
+                node = JsonNode.Parse(text);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
@@ -65,6 +65,41 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         public string? Description { get; set; }
     }
 
+    /// <summary>
+    /// A value pinned by the tool rather than supplied by the caller. Constants are invisible to the
+    /// model - they carry no schema - but are always written onto the underlying HTTP request.
+    /// </summary>
+    public sealed class McpToolConstantDescriptor
+    {
+        public McpToolConstantDescriptor(
+            string bindingName,
+            McpParameterSource source,
+            Type parameterType,
+            JsonNode? value)
+        {
+            BindingName = bindingName;
+            Source = source;
+            ParameterType = parameterType;
+            Value = value;
+        }
+
+        /// <summary>Route token, query key, header name, or JSON property inside the request body.</summary>
+        public string BindingName { get; }
+
+        public McpParameterSource Source { get; }
+
+        public Type ParameterType { get; }
+
+        /// <summary>The pinned value, already converted to the shape the action expects.</summary>
+        public JsonNode? Value { get; }
+
+        /// <summary>True when this value <em>is</em> the whole request body.</summary>
+        public bool IsBodyRoot { get; set; }
+
+        /// <summary>The tool input name this constant replaced, kept for diagnostics.</summary>
+        public string? ReplacedParameterName { get; set; }
+    }
+
     /// <summary>MCP tool annotations, mapped from HTTP semantics unless overridden.</summary>
     public sealed class McpToolAnnotations
     {
@@ -113,11 +148,19 @@ namespace Nabu.Mcp.AspNetCore.Discovery
 
         public ControllerActionDescriptor Action { get; }
 
+        /// <summary>Inputs the caller supplies. Excludes anything pinned through <see cref="Constants"/>.</summary>
         public IReadOnlyList<McpToolParameterDescriptor> Parameters { get; }
 
         public JsonObject InputSchema { get; }
 
         public McpToolAnnotations Annotations { get; }
+
+        /// <summary>
+        /// Values fixed by the tool definition and written onto every request, on top of whatever the
+        /// caller supplied. Populated from <see cref="McpToolAttribute.ConstantParameters"/>.
+        /// </summary>
+        public IReadOnlyList<McpToolConstantDescriptor> Constants { get; set; } =
+            new McpToolConstantDescriptor[0];
 
         /// <summary>
         /// Route values needed by endpoint matching in addition to the ones taken from the template

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
@@ -130,10 +130,10 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     continue;
                 }
 
-                McpToolDescriptor? tool;
+                List<McpToolDescriptor> tools;
                 try
                 {
-                    tool = TryCreateTool(action, used);
+                    tools = CreateTools(action, used);
                 }
                 catch (Exception ex)
                 {
@@ -145,57 +145,73 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     continue;
                 }
 
-                if (tool == null)
+                foreach (var tool in tools)
                 {
-                    continue;
-                }
+                    if (_options.ToolFilter != null && !_options.ToolFilter(tool))
+                    {
+                        continue;
+                    }
 
-                if (_options.ToolFilter != null && !_options.ToolFilter(tool))
-                {
-                    continue;
+                    results.Add(tool);
                 }
-
-                results.Add(tool);
             }
 
             results.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
             return results;
         }
 
-        private McpToolDescriptor? TryCreateTool(ControllerActionDescriptor action, ISet<string> usedNames)
+        /// <summary>
+        /// Builds every tool an action contributes. An action carrying several <see cref="McpToolAttribute"/>
+        /// occurrences yields one tool per occurrence, each with its own name and parameter set.
+        /// </summary>
+        private List<McpToolDescriptor> CreateTools(ControllerActionDescriptor action, ISet<string> usedNames)
         {
+            var empty = new List<McpToolDescriptor>();
             var method = action.MethodInfo;
             var controllerType = action.ControllerTypeInfo;
 
             if (method.GetCustomAttribute<McpIgnoreAttribute>() != null ||
                 controllerType.GetCustomAttribute<McpIgnoreAttribute>() != null)
             {
-                return null;
+                return empty;
             }
 
-            var methodAttribute = method.GetCustomAttribute<McpToolAttribute>(inherit: true);
-            var controllerAttribute = controllerType.GetCustomAttribute<McpToolAttribute>(inherit: true);
-            var attribute = methodAttribute ?? controllerAttribute;
+            var methodAttributes = method.GetCustomAttributes<McpToolAttribute>(inherit: true).ToList();
+            var controllerAttributes = controllerType.GetCustomAttributes<McpToolAttribute>(inherit: true).ToList();
+            var controllerAttribute = controllerAttributes.Count > 0 ? controllerAttributes[0] : null;
 
-            if (attribute == null && !_options.ExposeAllActions)
-            {
-                return null;
-            }
+            // A controller-wide [McpTool] is a default for the actions that carry none of their own; an
+            // action that declares its own variants replaces it rather than adding to it.
+            var isMethodLevel = methodAttributes.Count > 0;
+            var variants = new List<McpToolAttribute?>();
+            variants.AddRange(isMethodLevel ? methodAttributes : controllerAttributes);
 
-            if (attribute != null && !attribute.Enabled)
+            if (variants.Count == 0)
             {
-                return null;
-            }
+                if (!_options.ExposeAllActions)
+                {
+                    return empty;
+                }
 
-            if (attribute == null)
-            {
                 // Blanket exposure still respects the API explorer opt-out.
                 var apiExplorer = method.GetCustomAttribute<ApiExplorerSettingsAttribute>()
                                   ?? controllerType.GetCustomAttribute<ApiExplorerSettingsAttribute>();
                 if (apiExplorer != null && apiExplorer.IgnoreApi)
                 {
-                    return null;
+                    return empty;
                 }
+
+                variants.Add(null);
+            }
+
+            if (variants.Count > 1 && variants.Count(v => string.IsNullOrEmpty(v?.Name)) > 1)
+            {
+                _logger.LogWarning(
+                    "Nabu MCP found {Count} [McpTool] attributes on {Controller}.{Action} without an explicit Name. " +
+                    "Give each variant a name, otherwise all but the first are published under a generated '_2', '_3', ... suffix.",
+                    variants.Count,
+                    action.ControllerName,
+                    action.ActionName);
             }
 
             var httpMethod = ResolveHttpMethod(action);
@@ -206,26 +222,266 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     "Nabu MCP skipped {Controller}.{Action}: no route template could be resolved. Attribute routing is required.",
                     action.ControllerName,
                     action.ActionName);
-                return null;
+                return empty;
             }
 
-            var parameters = new List<McpToolParameterDescriptor>();
-            if (!TryBuildParameters(action, httpMethod, routeTemplate, parameters))
+            var allParameters = new List<McpToolParameterDescriptor>();
+            if (!TryBuildParameters(action, httpMethod, routeTemplate, allParameters))
             {
-                return null;
+                return empty;
             }
 
-            var inputSchema = BuildInputSchema(parameters);
-            var annotations = BuildAnnotations(attribute, methodAttribute, httpMethod, action);
-            var name = ResolveName(action, methodAttribute, httpMethod, routeTemplate, usedNames);
+            var results = new List<McpToolDescriptor>(variants.Count);
 
-            var tool = new McpToolDescriptor(name, httpMethod, routeTemplate, action, parameters, inputSchema, annotations)
+            foreach (var attribute in variants)
             {
-                Description = ResolveDescription(action, methodAttribute, controllerAttribute, httpMethod, routeTemplate),
-                ConstantRouteValues = new Dictionary<string, string?>(action.RouteValues, StringComparer.OrdinalIgnoreCase),
+                if (attribute != null && !attribute.Enabled)
+                {
+                    continue;
+                }
+
+                List<McpToolParameterDescriptor> parameters;
+                List<McpToolConstantDescriptor> constants;
+                if (!TryApplyVariant(action, attribute, routeTemplate, allParameters, out parameters, out constants))
+                {
+                    continue;
+                }
+
+                var methodAttribute = isMethodLevel ? attribute : null;
+                var inputSchema = BuildInputSchema(parameters);
+                var annotations = BuildAnnotations(attribute, methodAttribute, httpMethod, action);
+                var name = ResolveName(action, methodAttribute, httpMethod, routeTemplate, usedNames);
+
+                results.Add(new McpToolDescriptor(name, httpMethod, routeTemplate, action, parameters, inputSchema, annotations)
+                {
+                    Description = ResolveDescription(action, methodAttribute, controllerAttribute, httpMethod, routeTemplate),
+                    ConstantRouteValues = new Dictionary<string, string?>(action.RouteValues, StringComparer.OrdinalIgnoreCase),
+                    Constants = constants,
+                });
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Narrows the action's full input list down to the set one <see cref="McpToolAttribute"/> asks for.
+        /// Returns <c>false</c> when the variant cannot produce a callable tool.
+        /// </summary>
+        private bool TryApplyVariant(
+            ControllerActionDescriptor action,
+            McpToolAttribute? attribute,
+            string routeTemplate,
+            IReadOnlyList<McpToolParameterDescriptor> allParameters,
+            out List<McpToolParameterDescriptor> parameters,
+            out List<McpToolConstantDescriptor> constants)
+        {
+            parameters = new List<McpToolParameterDescriptor>(allParameters.Count);
+            constants = new List<McpToolConstantDescriptor>();
+
+            if (attribute == null)
+            {
+                parameters.AddRange(allParameters);
+                return true;
+            }
+
+            var include = BuildNameSet(attribute.IncludeParameters);
+            var exclude = BuildNameSet(attribute.ExcludeParameters);
+            var required = BuildNameSet(attribute.RequiredParameters);
+            var optional = BuildNameSet(attribute.OptionalParameters);
+            var pinned = BuildConstantMap(attribute, action);
+
+            WarnAboutUnknownNames(action, allParameters, include, exclude, required, optional, pinned?.Keys);
+
+            foreach (var parameter in allParameters)
+            {
+                // The route template renders every token it still contains, so dropping one of those
+                // inputs without pinning it would produce a tool that can never be invoked.
+                var isRequiredRouteToken = parameter.Source == McpParameterSource.Route &&
+                                           RouteTemplateHelper.ContainsToken(routeTemplate, parameter.BindingName);
+
+                string? constantText;
+                if (TryMatch(pinned, parameter, out constantText))
+                {
+                    var value = McpConstantValue.Convert(constantText!, parameter.ParameterType);
+                    if (value == null && isRequiredRouteToken)
+                    {
+                        _logger.LogWarning(
+                            "Nabu MCP skipped a [McpTool] variant on {Controller}.{Action}: route parameter '{Parameter}' " +
+                            "was pinned to an empty value but '{Template}' cannot be built without it.",
+                            action.ControllerName,
+                            action.ActionName,
+                            parameter.Name,
+                            routeTemplate);
+                        return false;
+                    }
+
+                    constants.Add(new McpToolConstantDescriptor(
+                        parameter.BindingName,
+                        parameter.Source,
+                        parameter.ParameterType,
+                        value)
+                    {
+                        IsBodyRoot = parameter.IsBodyRoot,
+                        ReplacedParameterName = parameter.Name,
+                    });
+
+                    continue;
+                }
+
+                var dropped = (include != null && !Matches(include, parameter)) ||
+                              (exclude != null && Matches(exclude, parameter));
+
+                if (dropped)
+                {
+                    if (isRequiredRouteToken)
+                    {
+                        _logger.LogWarning(
+                            "Nabu MCP skipped a [McpTool] variant on {Controller}.{Action}: route parameter '{Parameter}' " +
+                            "was hidden but '{Template}' cannot be built without it. Pin it with ConstantParameters instead.",
+                            action.ControllerName,
+                            action.ActionName,
+                            parameter.Name,
+                            routeTemplate);
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                var isRequired = parameter.IsRequired;
+                if (required != null && Matches(required, parameter))
+                {
+                    isRequired = true;
+                }
+                else if (optional != null && Matches(optional, parameter))
+                {
+                    isRequired = isRequiredRouteToken;
+                }
+
+                parameters.Add(isRequired == parameter.IsRequired ? parameter : WithRequired(parameter, isRequired));
+            }
+
+            return true;
+        }
+
+        private static McpToolParameterDescriptor WithRequired(McpToolParameterDescriptor parameter, bool isRequired)
+        {
+            return new McpToolParameterDescriptor(
+                parameter.Name,
+                parameter.BindingName,
+                parameter.Source,
+                parameter.ParameterType,
+                isRequired,
+                parameter.Schema)
+            {
+                IsBodyRoot = parameter.IsBodyRoot,
+                Description = parameter.Description,
             };
+        }
 
-            return tool;
+        private static ISet<string>? BuildNameSet(string[]? names)
+        {
+            if (names == null || names.Length == 0)
+            {
+                return null;
+            }
+
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var name in names)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    set.Add(name.Trim());
+                }
+            }
+
+            return set.Count == 0 ? null : set;
+        }
+
+        private IDictionary<string, string>? BuildConstantMap(McpToolAttribute attribute, ControllerActionDescriptor action)
+        {
+            var entries = attribute.ConstantParameters;
+            if (entries == null || entries.Length == 0)
+            {
+                return null;
+            }
+
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in entries)
+            {
+                string name;
+                string value;
+                if (!McpConstantValue.TrySplit(entry, out name, out value))
+                {
+                    _logger.LogWarning(
+                        "Nabu MCP ignored the ConstantParameters entry '{Entry}' on {Controller}.{Action}: expected 'name=value'.",
+                        entry,
+                        action.ControllerName,
+                        action.ActionName);
+                    continue;
+                }
+
+                map[name] = value;
+            }
+
+            return map.Count == 0 ? null : map;
+        }
+
+        /// <summary>A parameter is addressable by its tool input name or by its underlying binding name.</summary>
+        private static bool Matches(ISet<string> names, McpToolParameterDescriptor parameter)
+        {
+            return names.Contains(parameter.Name) || names.Contains(parameter.BindingName);
+        }
+
+        private static bool TryMatch(
+            IDictionary<string, string>? map,
+            McpToolParameterDescriptor parameter,
+            out string? value)
+        {
+            value = null;
+            if (map == null)
+            {
+                return false;
+            }
+
+            return map.TryGetValue(parameter.Name, out value) || map.TryGetValue(parameter.BindingName, out value);
+        }
+
+        /// <summary>
+        /// A misspelled parameter name would otherwise fail silently - the variant would simply expose
+        /// the full parameter set - so every configured name that matches nothing is reported.
+        /// </summary>
+        private void WarnAboutUnknownNames(
+            ControllerActionDescriptor action,
+            IReadOnlyList<McpToolParameterDescriptor> allParameters,
+            params IEnumerable<string>?[] configuredNames)
+        {
+            var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var parameter in allParameters)
+            {
+                known.Add(parameter.Name);
+                known.Add(parameter.BindingName);
+            }
+
+            foreach (var names in configuredNames)
+            {
+                if (names == null)
+                {
+                    continue;
+                }
+
+                foreach (var name in names)
+                {
+                    if (!known.Contains(name))
+                    {
+                        _logger.LogWarning(
+                            "Nabu MCP ignored '{Name}' in an [McpTool] variant on {Controller}.{Action}: the action has no such input.",
+                            name,
+                            action.ControllerName,
+                            action.ActionName);
+                    }
+                }
+            }
         }
 
         private string ResolveName(

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpArgumentBinder.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpArgumentBinder.cs
@@ -49,37 +49,83 @@ namespace Nabu.Mcp.AspNetCore.Execution
                     }
                 }
 
-                switch (parameter.Source)
+                Write(
+                    parameter.Source,
+                    parameter.BindingName,
+                    parameter.ParameterType,
+                    parameter.IsBodyRoot,
+                    value,
+                    replaceExisting: false);
+            }
+
+            // Constants are written last so a value pinned by the tool definition always wins over an
+            // argument that happens to bind to the same place.
+            foreach (var constant in tool.Constants)
+            {
+                if (constant.Value == null)
+                {
+                    continue;
+                }
+
+                Write(
+                    constant.Source,
+                    constant.BindingName,
+                    constant.ParameterType,
+                    constant.IsBodyRoot,
+                    constant.Value,
+                    replaceExisting: true);
+            }
+
+            void Write(
+                McpParameterSource source,
+                string bindingName,
+                Type parameterType,
+                bool isBodyRoot,
+                JsonNode? value,
+                bool replaceExisting)
+            {
+                switch (source)
                 {
                     case McpParameterSource.Route:
-                        routeValues[parameter.BindingName] = ToScalar(value) ?? string.Empty;
+                        routeValues[bindingName] = ToScalar(value) ?? string.Empty;
                         break;
 
                     case McpParameterSource.Header:
                         var header = ToScalar(value);
                         if (header != null)
                         {
-                            result.Headers[parameter.BindingName] = header;
+                            result.Headers[bindingName] = header;
                         }
 
                         break;
 
                     case McpParameterSource.Query:
-                        AppendQuery(query, parameter.BindingName, value);
+                        if (replaceExisting)
+                        {
+                            for (var i = query.Count - 1; i >= 0; i--)
+                            {
+                                if (string.Equals(query[i].Key, bindingName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    query.RemoveAt(i);
+                                }
+                            }
+                        }
+
+                        AppendQuery(query, bindingName, value);
                         break;
 
                     case McpParameterSource.Body:
                         var detached = value == null ? null : JsonNode.Parse(value.ToJsonString());
-                        detached = JsonBodyCoercion.Coerce(detached, parameter.ParameterType, compatibility);
+                        detached = JsonBodyCoercion.Coerce(detached, parameterType, compatibility);
 
-                        if (parameter.IsBodyRoot)
+                        if (isBodyRoot)
                         {
                             bodyRoot = detached;
                         }
                         else
                         {
                             bodyObject ??= new JsonObject();
-                            bodyObject[parameter.BindingName] = detached;
+                            bodyObject[bindingName] = detached;
                         }
 
                         break;

--- a/src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
+++ b/src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Nabu.Mcp.AspNetCore</RootNamespace>
     <AssemblyName>Nabu.Mcp.AspNetCore</AssemblyName>
     <PackageId>Nabu.Mcp.AspNetCore</PackageId>
+    <Title>Nabu.NET - MCP tools for ASP.NET Core Web APIs</Title>
     <Description>
       Expose existing ASP.NET Core Web API actions as Model Context Protocol (MCP) tools by adding a
       single [McpTool] attribute. Tool calls are replayed through the application's own HTTP pipeline,
@@ -17,6 +18,11 @@
     </Description>
     <PackageTags>mcp;model-context-protocol;aspnetcore;webapi;ai;llm;tools</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\LICENSE" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/ToolVariantTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/ToolVariantTests.cs
@@ -1,0 +1,190 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// Covers publishing one controller action several times, each occurrence of <c>[McpTool]</c>
+    /// narrowing the parameter set differently.
+    /// </summary>
+    [Collection(McpTestCollection.Name)]
+    public class ToolVariantTests
+    {
+        private readonly McpTestFixture _fixture;
+
+        public ToolVariantTests(McpTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        private async Task<JsonArray> ListToolsAsync()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var envelope = await _fixture.RpcAsync("tools/list", token: token);
+            return envelope["result"]!["tools"]!.AsArray();
+        }
+
+        private static JsonObject Find(JsonArray tools, string name)
+        {
+            var tool = tools.FirstOrDefault(t => t!["name"]!.GetValue<string>() == name);
+            Assert.NotNull(tool);
+            return tool!.AsObject();
+        }
+
+        private static string[] PropertyNames(JsonObject tool)
+        {
+            return tool["inputSchema"]!["properties"]!.AsObject().Select(p => p.Key).ToArray();
+        }
+
+        private static string[] RequiredNames(JsonObject tool)
+        {
+            var required = tool["inputSchema"]!["required"];
+            return required == null
+                ? new string[0]
+                : required.AsArray().Select(r => r!.GetValue<string>()).ToArray();
+        }
+
+        [Fact]
+        public async Task Every_McpTool_attribute_on_an_action_publishes_its_own_tool()
+        {
+            var tools = await ListToolsAsync();
+            var names = tools.Select(t => t!["name"]!.GetValue<string>()).ToArray();
+
+            // All three come from TodosController.List.
+            Assert.Contains("todos_list", names);
+            Assert.Contains("todos_list_open", names);
+            Assert.Contains("todos_search", names);
+        }
+
+        [Fact]
+        public async Task Variants_keep_their_own_title_and_description()
+        {
+            var tools = await ListToolsAsync();
+
+            var open = Find(tools, "todos_list_open");
+            Assert.Equal("List open todos", open["annotations"]!["title"]!.GetValue<string>());
+            Assert.Contains("still open", open["description"]!.GetValue<string>());
+
+            var search = Find(tools, "todos_search");
+            Assert.Equal("Search todos", search["annotations"]!["title"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task Excluded_and_pinned_parameters_disappear_from_the_schema()
+        {
+            var tools = await ListToolsAsync();
+
+            var all = PropertyNames(Find(tools, "todos_list"));
+            Assert.Contains("isCompleted", all);
+            Assert.Contains("priority", all);
+            Assert.Contains("search", all);
+
+            var open = PropertyNames(Find(tools, "todos_list_open"));
+            Assert.DoesNotContain("isCompleted", open); // pinned
+            Assert.DoesNotContain("priority", open);    // excluded
+            Assert.DoesNotContain("search", open);      // excluded
+            Assert.Contains("page", open);
+            Assert.Contains("pageSize", open);
+        }
+
+        [Fact]
+        public async Task IncludeParameters_keeps_only_the_listed_inputs()
+        {
+            var tools = await ListToolsAsync();
+            var search = PropertyNames(Find(tools, "todos_search"));
+
+            Assert.Equal(new[] { "search", "page", "pageSize" }, search);
+        }
+
+        [Fact]
+        public async Task RequiredParameters_promotes_an_optional_input()
+        {
+            var tools = await ListToolsAsync();
+
+            Assert.Empty(RequiredNames(Find(tools, "todos_list")));
+            Assert.Equal(new[] { "search" }, RequiredNames(Find(tools, "todos_search")));
+        }
+
+        [Fact]
+        public async Task A_pinned_value_is_applied_to_the_underlying_request()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            var created = McpTestFixture.JsonOf(await _fixture.CallToolAsync(
+                "todos_create",
+                new JsonObject { ["title"] = "Pinned argument probe" },
+                token));
+            var id = created["id"]!.GetValue<string>();
+
+            var ids = await OpenIdsAsync(token);
+            Assert.Contains(id, ids);
+
+            await _fixture.CallToolAsync(
+                "todos_update",
+                new JsonObject { ["id"] = id, ["isCompleted"] = true },
+                token);
+
+            // The pinned isCompleted=false is the only thing that can drop it from the list; the plain
+            // todos_list tool, which applies no filter, must still return it.
+            Assert.DoesNotContain(id, await OpenIdsAsync(token));
+
+            var all = McpTestFixture.JsonOf(
+                await _fixture.CallToolAsync("todos_list", new JsonObject { ["pageSize"] = 100 }, token));
+            Assert.Contains(id, all["items"]!.AsArray().Select(i => i!["id"]!.GetValue<string>()));
+        }
+
+        private async Task<string[]> OpenIdsAsync(System.Net.Http.Headers.AuthenticationHeaderValue token)
+        {
+            var open = McpTestFixture.JsonOf(
+                await _fixture.CallToolAsync("todos_list_open", new JsonObject { ["pageSize"] = 100 }, token));
+
+            Assert.All(
+                open["items"]!.AsArray(),
+                item => Assert.False(item!["isCompleted"]!.GetValue<bool>()));
+
+            return open["items"]!.AsArray().Select(i => i!["id"]!.GetValue<string>()).ToArray();
+        }
+
+        [Fact]
+        public async Task A_pinned_value_overrides_an_argument_that_targets_the_same_input()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            // "isCompleted" is not part of todos_list_open's schema; supplying it anyway must not win
+            // over the pinned value.
+            var result = McpTestFixture.JsonOf(await _fixture.CallToolAsync(
+                "todos_list_open",
+                new JsonObject { ["isCompleted"] = true, ["pageSize"] = 100 },
+                token));
+
+            Assert.All(
+                result["items"]!.AsArray(),
+                item => Assert.False(item!["isCompleted"]!.GetValue<bool>()));
+        }
+
+        [Fact]
+        public async Task A_route_token_can_be_pinned_leaving_a_tool_with_no_arguments()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var tools = await ListToolsAsync();
+            var tool = Find(tools, "weather_get_yerevan_week");
+
+            Assert.Empty(PropertyNames(tool));
+
+            var forecast = McpTestFixture.JsonOf(
+                await _fixture.CallToolAsync("weather_get_yerevan_week", new JsonObject(), token));
+
+            Assert.Equal(7, forecast.AsArray().Count);
+
+            // Same city, so the deterministic forecast must match the general-purpose tool.
+            var direct = McpTestFixture.JsonOf(await _fixture.CallToolAsync(
+                "weather_get_forecast",
+                new JsonObject { ["city"] = "Yerevan", ["days"] = 7 },
+                token));
+
+            Assert.Equal(direct.ToJsonString(), forecast.ToJsonString());
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Unit/McpConstantValueTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Unit/McpConstantValueTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Nabu.Mcp.AspNetCore.Discovery;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Unit
+{
+    public class McpConstantValueTests
+    {
+        [Theory]
+        [InlineData("status=open", "status", "open")]
+        [InlineData("  status  =open", "status", "open")]
+        [InlineData("filter=a=b", "filter", "a=b")]
+        [InlineData("flag", "flag", "")]
+        [InlineData("pageSize=", "pageSize", "")]
+        public void TrySplit_takes_everything_after_the_first_equals_as_the_value(
+            string entry,
+            string expectedName,
+            string expectedValue)
+        {
+            string name;
+            string value;
+
+            Assert.True(McpConstantValue.TrySplit(entry, out name, out value));
+            Assert.Equal(expectedName, name);
+            Assert.Equal(expectedValue, value);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("=orphan")]
+        public void TrySplit_rejects_entries_without_a_name(string? entry)
+        {
+            string name;
+            string value;
+
+            Assert.False(McpConstantValue.TrySplit(entry, out name, out value));
+        }
+
+        [Fact]
+        public void Strings_are_passed_through_untouched()
+        {
+            var value = McpConstantValue.Convert("  spaced  ", typeof(string));
+            Assert.Equal("  spaced  ", value!.GetValue<string>());
+
+            // "null" is a legitimate string, not an absent value.
+            Assert.Equal("null", McpConstantValue.Convert("null", typeof(string))!.GetValue<string>());
+        }
+
+        [Theory]
+        [InlineData("42", typeof(int))]
+        [InlineData("42", typeof(long))]
+        [InlineData("42", typeof(int?))]
+        public void Integers_become_json_numbers(string raw, Type type)
+        {
+            var value = McpConstantValue.Convert(raw, type);
+            Assert.Equal(JsonValueKind.Number, value!.GetValueKind());
+            Assert.Equal(42, value.GetValue<long>());
+        }
+
+        [Fact]
+        public void Decimals_become_json_numbers()
+        {
+            var value = McpConstantValue.Convert("1.5", typeof(double));
+            Assert.Equal(JsonValueKind.Number, value!.GetValueKind());
+            Assert.Equal(1.5m, value.GetValue<decimal>());
+        }
+
+        [Theory]
+        [InlineData("false", false)]
+        [InlineData("True", true)]
+        public void Booleans_become_json_booleans(string raw, bool expected)
+        {
+            var value = McpConstantValue.Convert(raw, typeof(bool?));
+            Assert.Equal(expected, value!.GetValue<bool>());
+        }
+
+        [Fact]
+        public void Enums_stay_textual_so_the_body_coercion_can_map_them()
+        {
+            var value = McpConstantValue.Convert("High", typeof(DayOfWeek?));
+            Assert.Equal(JsonValueKind.String, value!.GetValueKind());
+        }
+
+        [Fact]
+        public void Complex_parameters_accept_a_json_literal()
+        {
+            var value = McpConstantValue.Convert("[\"docs\",\"ops\"]", typeof(List<string>));
+            Assert.Equal(JsonValueKind.Array, value!.GetValueKind());
+            Assert.Equal(2, value.AsArray().Count);
+        }
+
+        [Fact]
+        public void A_value_that_is_not_valid_json_falls_back_to_a_string()
+        {
+            var value = McpConstantValue.Convert("{not json", typeof(List<string>));
+            Assert.Equal(JsonValueKind.String, value!.GetValueKind());
+        }
+
+        [Theory]
+        [InlineData("", typeof(int?))]
+        [InlineData("null", typeof(int?))]
+        [InlineData("NULL", typeof(bool))]
+        public void An_empty_or_null_value_on_a_non_string_parameter_sends_nothing(string raw, Type type)
+        {
+            Assert.Null(McpConstantValue.Convert(raw, type));
+        }
+
+        [Fact]
+        public void A_number_that_does_not_parse_falls_back_to_a_string_so_the_binder_can_complain()
+        {
+            var value = McpConstantValue.Convert("not-a-number", typeof(int));
+            Assert.Equal(JsonValueKind.String, value!.GetValueKind());
+        }
+    }
+}


### PR DESCRIPTION
[McpTool] is now repeatable. Each occurrence on an action publishes its own
tool over the same endpoint, so a single action can back several tools with
different names, descriptions and parameter sets:

  IncludeParameters   whitelist of inputs to expose
  ExcludeParameters   inputs to hide, leaving the action's defaults to apply
  ConstantParameters  name=value pairs pinned by the tool and hidden from the
                      schema, converted to the parameter's CLR type
  RequiredParameters  promote an optional input to required
  OptionalParameters  the reverse

Constants are written onto the synthetic request after the caller's arguments,
so a pinned value always wins. Route tokens can be pinned too, which collapses
an endpoint into a zero-argument tool; hiding a route token the URL needs is
reported and the variant is skipped rather than published uncallable.

Adds CI (build, test, pack on push and PR) and a tag-driven release workflow
that packs and pushes to nuget.org with the version taken from the v* tag, and
fills in the package metadata: author, project URL and repository URL, plus the
README, license file and Source Link symbols.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CBXQsS9odBschKxed1A7Xp