### PR TITLE
Add MCP protocol revision 2026-07-28 support alongside the legacy han…

### DIFF
--- a/Nabu.NET.sln
+++ b/Nabu.NET.sln
@@ -15,31 +15,74 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{953F87EF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nabu.Mcp.AspNetCore.Tests", "tests\Nabu.Mcp.AspNetCore.Tests\Nabu.Mcp.AspNetCore.Tests.csproj", "{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nabu.Mcp.ModelContextProtocol", "src\Nabu.Mcp.ModelContextProtocol\Nabu.Mcp.ModelContextProtocol.csproj", "{6FB05845-D5C8-4796-839C-12DECC570512}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Debug|x64.Build.0 = Debug|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Debug|x86.Build.0 = Debug|Any CPU
 		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Release|x64.ActiveCfg = Release|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Release|x64.Build.0 = Release|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Release|x86.ActiveCfg = Release|Any CPU
+		{538BD570-0350-4CD4-865D-3C4089C2B4C6}.Release|x86.Build.0 = Release|Any CPU
 		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Debug|x86.Build.0 = Debug|Any CPU
 		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Release|x64.Build.0 = Release|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B994537-17FB-4D0A-B150-C9C23FE07D4B}.Release|x86.Build.0 = Release|Any CPU
 		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Debug|x64.Build.0 = Debug|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Debug|x86.Build.0 = Debug|Any CPU
 		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Release|x64.ActiveCfg = Release|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Release|x64.Build.0 = Release|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Release|x86.ActiveCfg = Release|Any CPU
+		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401}.Release|x86.Build.0 = Release|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Debug|x64.Build.0 = Debug|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Debug|x86.Build.0 = Debug|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Release|x64.ActiveCfg = Release|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Release|x64.Build.0 = Release|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Release|x86.ActiveCfg = Release|Any CPU
+		{6FB05845-D5C8-4796-839C-12DECC570512}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{538BD570-0350-4CD4-865D-3C4089C2B4C6} = {A112FA9A-362C-4BDA-8ECE-CE947D15A77E}
 		{3B994537-17FB-4D0A-B150-C9C23FE07D4B} = {B05E5686-1D65-4C6F-9D3D-46085308BD61}
 		{D6F87D30-AD26-4AA5-A06C-05D0ACE14401} = {953F87EF-0B57-4E51-8FE2-5751C5EA85DA}
+		{6FB05845-D5C8-4796-839C-12DECC570512} = {A112FA9A-362C-4BDA-8ECE-CE947D15A77E}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ app.MapControllers();
 app.Run();
 ```
 
-`UseNabuMcp()` serves the MCP endpoint at `/mcp` by default. Where you place it only affects the MCP
-endpoint itself - tool calls always traverse the whole pipeline from the top, regardless of position.
+`UseNabuMcp()` serves the MCP endpoint at `/mcp` by default. The route can be changed either
+through `options.Path` or directly at the mount - `app.UseNabuMcp("/agent/mcp")` - with the
+argument winning when both are set. Where you place it only affects the MCP endpoint itself -
+tool calls always traverse the whole pipeline from the top, regardless of position.
 
 ### 3. Mark the actions you want to publish
 
@@ -467,6 +469,36 @@ Failures are reported at the right layer: a bad tool name or a missing required 
 error (`-32602`), while an HTTP error from the action - 400 from validation, 403 from a policy, 404
 from the action - is a successful JSON-RPC response carrying `isError: true`, which is what lets a
 model read and react to it.
+
+### Using the official MCP SDK as the protocol layer
+
+Nabu's value is the ASP.NET Core bridge - controller discovery, schema generation,
+authorization-aware visibility and pipeline replay - not the JSON-RPC plumbing. The protocol
+layer is therefore replaceable. The `Nabu.Mcp.ModelContextProtocol` package serves Nabu's tools
+through the official [ModelContextProtocol C# SDK](https://github.com/modelcontextprotocol/csharp-sdk)
+instead of the built-in layer:
+
+```csharp
+services.AddNabuMcp(options => { ... })
+        .UseOfficialMcpProtocol();
+
+app.UseNabuMcp(); // now mounts the official SDK's Streamable HTTP endpoint at the same path
+```
+
+The SDK owns the wire protocol - transport, protocol revisions, sessions - and Nabu answers
+`tools/list` and `tools/call` behind it, with the same visibility rules and pipeline replay as
+the built-in layer. The transport defaults to the SDK's stateless mode, matching Nabu's design;
+pass a configuration delegate to change that or any other transport option:
+
+```csharp
+services.AddNabuMcp().UseOfficialMcpProtocol(transport => transport.Stateless = false);
+```
+
+Choose the built-in layer for netstandard2.0/ASP.NET Core 2.x compatibility and zero extra
+dependencies; choose the official layer (net8.0+) to track the protocol at the SDK's pace and
+pick up its transport features. `RequireAuthorization` is honoured on the mapped endpoint; the
+partial `AnonymousAccess` modes leave the endpoint anonymous and rely on the replayed pipeline
+to authorize each call.
 
 ## Target frameworks
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,8 @@ All options live on `NabuMcpOptions`:
 | Option | Default | Meaning |
 |---|---|---|
 | `Path` | `/mcp` | Endpoint path. |
-| `ServerName`, `ServerVersion`, `Instructions` | entry assembly | Reported during `initialize`. |
+| `ServerName`, `ServerVersion`, `Instructions` | entry assembly | Reported during `initialize` / `server/discover`. |
+| `CacheTtlMilliseconds` | `60000` | `ttlMs` freshness hint on cacheable `2026-07-28` results. |
 | `ExposeAllActions` | `false` | Publish every action, not just annotated ones. `[McpIgnore]` still wins. |
 | `RequireAuthorization`, `AuthorizationPolicy`, `AuthenticationSchemes` | off | Protects the MCP endpoint. |
 | `ToolVisibility` | `All` | Advertise every tool, or only the ones the caller is authenticated / authorized for. |
@@ -435,21 +436,32 @@ All options live on `NabuMcpOptions`:
 
 ## Protocol support
 
-Streamable HTTP transport, JSON-RPC 2.0, protocol revisions `2025-06-18`, `2025-03-26` and
-`2024-11-05` (negotiated at `initialize`).
+Streamable HTTP transport, JSON-RPC 2.0. The server is dual-era: it speaks the stateless
+revision `2026-07-28` (version and capabilities declared in `_meta` on every request, no
+handshake, no sessions) and the legacy revisions `2025-06-18`, `2025-03-26` and `2024-11-05`
+(negotiated at `initialize`). A request that declares a protocol version in `_meta` — or calls
+`server/discover` — is served under `2026-07-28` semantics; everything else stays on the
+legacy path, so existing clients are unaffected.
+
+On the `2026-07-28` path the mirrored request headers (`MCP-Protocol-Version`, `Mcp-Method`,
+`Mcp-Name`) are validated against the body (`-32020` on mismatch), an unsupported version is
+answered with `-32022` and the supported list, results carry `resultType`, the server's
+identity in `_meta`, and `ttlMs`/`cacheScope` on cacheable results, and no session id is ever
+minted.
 
 | Method | Behaviour |
 |---|---|
-| `initialize` | Negotiates the version, advertises the `tools` capability, returns a session id. |
+| `server/discover` | (`2026-07-28`) Supported versions, capabilities, identity and instructions. |
+| `initialize` | (legacy) Negotiates the version, advertises the `tools` capability, returns a session id. |
 | `tools/list` | Every discovered tool with its schema and annotations. |
 | `tools/call` | Replays the action; returns text content, `structuredContent`, and `isError`. |
-| `ping` | Answered with an empty result. |
+| `ping` | (legacy) Answered with an empty result. |
 | `notifications/*` | Accepted with `202` and no body. |
 | `resources/list`, `resources/templates/list`, `prompts/list` | Answered as empty for client compatibility. |
 
 `POST` returns `application/json`, or a single server-sent event when the client accepts only
-`text/event-stream`. Batched arrays are supported. `DELETE` ends a session (the server is stateless, so
-this is a no-op). `GET` returns `405`.
+`text/event-stream`. Batched arrays are supported on the legacy path. `DELETE` ends a legacy
+session (the server is stateless, so this is a no-op). `GET` returns `405`.
 
 Failures are reported at the right layer: a bad tool name or a missing required argument is a JSON-RPC
 error (`-32602`), while an HTTP error from the action - 400 from validation, 403 from a policy, 404

--- a/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpApplicationBuilderExtensions.cs
+++ b/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpApplicationBuilderExtensions.cs
@@ -29,10 +29,17 @@ namespace Nabu.Mcp.AspNetCore
                     "UseNabuMcp() requires AddNabuMcp() to have been called on the service collection.");
             }
 
+            var options = app.ApplicationServices.GetRequiredService<IOptions<NabuMcpOptions>>().Value;
             if (!string.IsNullOrEmpty(path))
             {
-                var options = app.ApplicationServices.GetRequiredService<IOptions<NabuMcpOptions>>().Value;
                 options.Path = path!.StartsWith("/", StringComparison.Ordinal) ? path : "/" + path;
+            }
+
+            var mount = app.ApplicationServices.GetService<INabuMcpProtocolMount>();
+            if (mount != null)
+            {
+                mount.Mount(app, options.Path);
+                return app;
             }
 
             return app.UseMiddleware<McpMiddleware>();

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
@@ -39,6 +39,8 @@ namespace Nabu.Mcp.AspNetCore.Execution
             "Upgrade",
             McpConstants.SessionIdHeader,
             McpConstants.ProtocolVersionHeader,
+            McpConstants.MethodHeader,
+            McpConstants.NameHeader,
         };
 
         private readonly McpPipelineProvider _pipelineProvider;

--- a/src/Nabu.Mcp.AspNetCore/McpConstants.cs
+++ b/src/Nabu.Mcp.AspNetCore/McpConstants.cs
@@ -3,10 +3,12 @@ namespace Nabu.Mcp.AspNetCore
     /// <summary>Protocol level constants used by the MCP endpoint.</summary>
     public static class McpConstants
     {
-        /// <summary>The MCP revision this server implements.</summary>
+        /// <summary>The legacy MCP revision this server negotiates at <c>initialize</c>.</summary>
         public const string ProtocolVersion = "2025-06-18";
 
-        /// <summary>Protocol revisions this server is able to speak.</summary>
+        /// <summary>
+        /// Legacy protocol revisions negotiated through the <c>initialize</c> handshake.
+        /// </summary>
         public static readonly string[] SupportedProtocolVersions =
         {
             "2025-06-18",
@@ -14,8 +16,26 @@ namespace Nabu.Mcp.AspNetCore
             "2024-11-05",
         };
 
+        /// <summary>
+        /// Modern protocol revisions, declared per request via <c>_meta</c> instead of a handshake.
+        /// Kept separate from <see cref="SupportedProtocolVersions"/> because a client that picks a
+        /// version from this list must not be steered towards one that only works via <c>initialize</c>.
+        /// </summary>
+        public static readonly string[] ModernProtocolVersions =
+        {
+            "2026-07-28",
+        };
+
         public const string SessionIdHeader = "Mcp-Session-Id";
         public const string ProtocolVersionHeader = "MCP-Protocol-Version";
+        public const string MethodHeader = "Mcp-Method";
+        public const string NameHeader = "Mcp-Name";
+
+        // _meta keys defined by revision 2026-07-28.
+        public const string ProtocolVersionMetaKey = "io.modelcontextprotocol/protocolVersion";
+        public const string ClientCapabilitiesMetaKey = "io.modelcontextprotocol/clientCapabilities";
+        public const string ClientInfoMetaKey = "io.modelcontextprotocol/clientInfo";
+        public const string ServerInfoMetaKey = "io.modelcontextprotocol/serverInfo";
 
         public const string JsonContentType = "application/json";
         public const string EventStreamContentType = "text/event-stream";
@@ -40,5 +60,9 @@ namespace Nabu.Mcp.AspNetCore
         public const int MethodNotFound = -32601;
         public const int InvalidParams = -32602;
         public const int InternalError = -32603;
+
+        // Error codes reserved by the MCP specification (revision 2026-07-28).
+        public const int HeaderMismatch = -32020;
+        public const int UnsupportedProtocolVersion = -32022;
     }
 }

--- a/src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
+++ b/src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Nabu.Mcp.AspNetCore.Tests" />
+    <InternalsVisibleTo Include="Nabu.Mcp.ModelContextProtocol" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Nabu.Mcp.AspNetCore/NabuMcpOptions.cs
+++ b/src/Nabu.Mcp.AspNetCore/NabuMcpOptions.cs
@@ -67,6 +67,14 @@ namespace Nabu.Mcp.AspNetCore
         /// <summary>Free-form guidance handed to the model alongside the tool list.</summary>
         public string? Instructions { get; set; }
 
+        /// <summary>
+        /// Freshness hint, in milliseconds, stamped as <c>ttlMs</c> on the cacheable results
+        /// (<c>server/discover</c> and the listing methods) served to 2026-07-28 clients. The tool
+        /// registry is fixed at startup, but what a caller is shown can depend on its credentials,
+        /// so keep this short enough that a client re-lists soon after authenticating.
+        /// </summary>
+        public int CacheTtlMilliseconds { get; set; } = 60_000;
+
         /// <summary>Path the MCP endpoint is served from. Defaults to <c>/mcp</c>.</summary>
         public string Path { get; set; } = "/mcp";
 

--- a/src/Nabu.Mcp.AspNetCore/Protocol/ModernProtocol.cs
+++ b/src/Nabu.Mcp.AspNetCore/Protocol/ModernProtocol.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Text;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+
+namespace Nabu.Mcp.AspNetCore.Protocol
+{
+    /// <summary>
+    /// Per-request mechanics of protocol revision 2026-07-28, where the protocol version, client
+    /// identity and capabilities travel in <c>_meta</c> on every request instead of being negotiated
+    /// through an <c>initialize</c> handshake.
+    /// </summary>
+    internal static class ModernProtocol
+    {
+        private const string Base64Prefix = "=?base64?";
+        private const string Base64Suffix = "?=";
+
+        /// <summary>The protocol version declared in the request's <c>_meta</c>, or <c>null</c>.</summary>
+        internal static string? DeclaredVersion(JsonRpcRequest request)
+        {
+            var meta = request.Parameters?["_meta"] as JsonObject;
+            var node = meta?[McpConstants.ProtocolVersionMetaKey];
+            return node is JsonValue value && value.TryGetValue<string>(out var version) ? version : null;
+        }
+
+        /// <summary>
+        /// Whether this request must be served under per-request-metadata semantics. Declaring a
+        /// protocol version in <c>_meta</c> is what separates the eras - legacy clients never send
+        /// that key - and <c>server/discover</c> only exists in the modern protocol, so it counts
+        /// even when the metadata was left out.
+        /// </summary>
+        internal static bool IsModern(JsonRpcRequest request)
+        {
+            return DeclaredVersion(request) != null ||
+                   string.Equals(request.Method, "server/discover", StringComparison.Ordinal);
+        }
+
+        internal static bool IsSupportedVersion(string version)
+        {
+            foreach (var supported in McpConstants.ModernProtocolVersions)
+            {
+                if (string.Equals(supported, version, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Validates the request headers the transport mirrors from the body
+        /// (<c>MCP-Protocol-Version</c>, <c>Mcp-Method</c>, <c>Mcp-Name</c>), so that an intermediary
+        /// routing on a header can never disagree with what the server executes. Returns the message
+        /// for a <c>HeaderMismatch</c> error, or <c>null</c> when the request is valid.
+        /// </summary>
+        internal static string? ValidateHeaders(HttpContext context, JsonRpcRequest request, string? declaredVersion)
+        {
+            var headerVersion = context.Request.Headers[McpConstants.ProtocolVersionHeader].ToString();
+            if (string.IsNullOrEmpty(headerVersion))
+            {
+                return "The " + McpConstants.ProtocolVersionHeader + " header is required.";
+            }
+
+            if (declaredVersion == null)
+            {
+                return "The '" + McpConstants.ProtocolVersionMetaKey + "' _meta field is required.";
+            }
+
+            if (!string.Equals(headerVersion, declaredVersion, StringComparison.Ordinal))
+            {
+                return "Header mismatch: " + McpConstants.ProtocolVersionHeader + " value '" + headerVersion +
+                       "' does not match the _meta value '" + declaredVersion + "'.";
+            }
+
+            var headerMethod = context.Request.Headers[McpConstants.MethodHeader].ToString();
+            if (string.IsNullOrEmpty(headerMethod))
+            {
+                return "The " + McpConstants.MethodHeader + " header is required.";
+            }
+
+            if (!string.Equals(headerMethod, request.Method, StringComparison.Ordinal))
+            {
+                return "Header mismatch: " + McpConstants.MethodHeader + " value '" + headerMethod +
+                       "' does not match the request method '" + request.Method + "'.";
+            }
+
+            // Mcp-Name mirrors params.name (or params.uri). When the body value is missing the
+            // header is not expected, and the handler reports the missing parameter instead.
+            var bodyName = NamedValue(request);
+            if (bodyName != null)
+            {
+                var headerName = context.Request.Headers[McpConstants.NameHeader].ToString();
+                if (string.IsNullOrEmpty(headerName))
+                {
+                    return "The " + McpConstants.NameHeader + " header is required for " + request.Method + ".";
+                }
+
+                var decoded = DecodeHeaderValue(headerName);
+                if (decoded == null || !string.Equals(decoded, bodyName, StringComparison.Ordinal))
+                {
+                    return "Header mismatch: " + McpConstants.NameHeader + " value '" + headerName +
+                           "' does not match the body value '" + bodyName + "'.";
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>The body value the <c>Mcp-Name</c> header mirrors, for methods that carry one.</summary>
+        private static string? NamedValue(JsonRpcRequest request)
+        {
+            switch (request.Method)
+            {
+                case "tools/call":
+                case "prompts/get":
+                    return AsString(request.Parameters?["name"]);
+
+                case "resources/read":
+                    return AsString(request.Parameters?["uri"]);
+
+                default:
+                    return null;
+            }
+        }
+
+        private static string? AsString(JsonNode? node)
+        {
+            return node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+        }
+
+        /// <summary>
+        /// Undoes the transport's Base64 sentinel encoding (<c>=?base64?...?=</c>) used for header
+        /// values that are not header-safe ASCII. Returns <c>null</c> for a malformed encoding.
+        /// </summary>
+        internal static string? DecodeHeaderValue(string value)
+        {
+            if (!value.StartsWith(Base64Prefix, StringComparison.Ordinal) ||
+                !value.EndsWith(Base64Suffix, StringComparison.Ordinal) ||
+                value.Length < Base64Prefix.Length + Base64Suffix.Length)
+            {
+                return value;
+            }
+
+            var encoded = value.Substring(Base64Prefix.Length, value.Length - Base64Prefix.Length - Base64Suffix.Length);
+            try
+            {
+                return Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Server/INabuMcpProtocolMount.cs
+++ b/src/Nabu.Mcp.AspNetCore/Server/INabuMcpProtocolMount.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Nabu.Mcp.AspNetCore.Server
+{
+    /// <summary>
+    /// Replaces the built-in protocol endpoint. When a mount is registered,
+    /// <c>UseNabuMcp()</c> hands it the resolved endpoint path instead of adding the built-in
+    /// middleware, so an alternative MCP protocol implementation (such as the official SDK, via
+    /// the <c>Nabu.Mcp.ModelContextProtocol</c> package) can serve Nabu's tools. Discovery,
+    /// schema generation and pipeline replay are unaffected - only the wire protocol changes.
+    /// </summary>
+    public interface INabuMcpProtocolMount
+    {
+        /// <summary>Mounts the protocol endpoint at <paramref name="path"/>.</summary>
+        void Mount(IApplicationBuilder app, string path);
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Server/McpMiddleware.cs
+++ b/src/Nabu.Mcp.AspNetCore/Server/McpMiddleware.cs
@@ -246,6 +246,15 @@ namespace Nabu.Mcp.AspNetCore.Server
                 }
             }
 
+            // A single request that declares its protocol version in _meta (or calls the
+            // handshake-free server/discover) is served under revision 2026-07-28 semantics.
+            // Batches stay on the legacy path: modern transports post one message at a time.
+            if (!isBatch && requests.Count == 1 && ModernProtocol.IsModern(requests[0]))
+            {
+                await HandleModernPostAsync(context, handler, requests[0]).ConfigureAwait(false);
+                return;
+            }
+
             var responses = new JsonArray();
             var hasInitialize = false;
 
@@ -293,6 +302,66 @@ namespace Nabu.Mcp.AspNetCore.Server
             else
             {
                 await WriteJsonAsync(context, result).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Serves one revision 2026-07-28 request: validates the mirrored headers and the declared
+        /// protocol version, then dispatches. No session id is ever minted on this path.
+        /// </summary>
+        private async Task HandleModernPostAsync(HttpContext context, McpRequestHandler handler, JsonRpcRequest request)
+        {
+            if (request.IsNotification)
+            {
+                // Header requirements for notification POSTs are not defined by this revision;
+                // the transport just wants them acknowledged without a body.
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return;
+            }
+
+            var declaredVersion = ModernProtocol.DeclaredVersion(request);
+
+            var headerError = ModernProtocol.ValidateHeaders(context, request, declaredVersion);
+            if (headerError != null)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await WriteJsonAsync(context, JsonRpc.Error(request.Id, McpConstants.HeaderMismatch, headerError))
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            if (!ModernProtocol.IsSupportedVersion(declaredVersion!))
+            {
+                var supported = new JsonArray();
+                foreach (var version in McpConstants.ModernProtocolVersions)
+                {
+                    supported.Add(version);
+                }
+
+                var data = new JsonObject
+                {
+                    ["supported"] = supported,
+                    ["requested"] = declaredVersion,
+                };
+
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await WriteJsonAsync(
+                    context,
+                    JsonRpc.Error(request.Id, McpConstants.UnsupportedProtocolVersion, "Unsupported protocol version", data))
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            var response = await handler.HandleModernAsync(request, context, context.RequestAborted).ConfigureAwait(false);
+            context.Response.StatusCode = response.StatusCode;
+
+            if (PrefersEventStream(context))
+            {
+                await WriteEventStreamAsync(context, response.Body).ConfigureAwait(false);
+            }
+            else
+            {
+                await WriteJsonAsync(context, response.Body).ConfigureAwait(false);
             }
         }
 

--- a/src/Nabu.Mcp.AspNetCore/Server/McpRequestHandler.cs
+++ b/src/Nabu.Mcp.AspNetCore/Server/McpRequestHandler.cs
@@ -269,7 +269,7 @@ namespace Nabu.Mcp.AspNetCore.Server
             return result;
         }
 
-        private async Task<JsonObject> ListToolsAsync(HttpContext context, CancellationToken cancellationToken)
+        internal async Task<JsonObject> ListToolsAsync(HttpContext context, CancellationToken cancellationToken)
         {
             var tools = new JsonArray();
             var hidden = 0;

--- a/src/Nabu.Mcp.AspNetCore/Server/McpRequestHandler.cs
+++ b/src/Nabu.Mcp.AspNetCore/Server/McpRequestHandler.cs
@@ -104,6 +104,132 @@ namespace Nabu.Mcp.AspNetCore.Server
             }
         }
 
+        /// <summary>
+        /// Handles one request under revision 2026-07-28 semantics: no handshake, no session, the
+        /// version validated per request and every result stamped with <c>resultType</c> and the
+        /// server's identity. Returns the response body together with the HTTP status the transport
+        /// prescribes for it.
+        /// </summary>
+        public async Task<ModernMcpResponse> HandleModernAsync(JsonRpcRequest request, HttpContext context, CancellationToken cancellationToken)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            try
+            {
+                switch (request.Method)
+                {
+                    case "server/discover":
+                        return ModernMcpResponse.Ok(JsonRpc.Result(request.Id, Discover()));
+
+                    case "tools/list":
+                        return ModernMcpResponse.Ok(JsonRpc.Result(
+                            request.Id,
+                            Cacheable(Modern(await ListToolsAsync(context, cancellationToken).ConfigureAwait(false)))));
+
+                    case "tools/call":
+                        return ModernMcpResponse.Ok(JsonRpc.Result(
+                            request.Id,
+                            Modern(await CallToolAsync(request, context, cancellationToken).ConfigureAwait(false))));
+
+                    case "resources/list":
+                        return ModernMcpResponse.Ok(JsonRpc.Result(
+                            request.Id,
+                            Cacheable(Modern(new JsonObject { ["resources"] = new JsonArray() }))));
+
+                    case "resources/templates/list":
+                        return ModernMcpResponse.Ok(JsonRpc.Result(
+                            request.Id,
+                            Cacheable(Modern(new JsonObject { ["resourceTemplates"] = new JsonArray() }))));
+
+                    case "prompts/list":
+                        return ModernMcpResponse.Ok(JsonRpc.Result(
+                            request.Id,
+                            Cacheable(Modern(new JsonObject { ["prompts"] = new JsonArray() }))));
+
+                    default:
+                        // The transport distinguishes an unknown method from a legacy server that
+                        // does not host the endpoint at all by pairing 404 with a JSON-RPC error.
+                        return new ModernMcpResponse(
+                            JsonRpc.Error(request.Id, McpConstants.MethodNotFound, "Method '" + request.Method + "' is not supported."),
+                            StatusCodes.Status404NotFound);
+                }
+            }
+            catch (McpArgumentException ex)
+            {
+                return ModernMcpResponse.Ok(JsonRpc.Error(request.Id, McpConstants.InvalidParams, ex.Message));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Nabu MCP failed to handle method {Method}.", request.Method);
+                return ModernMcpResponse.Ok(JsonRpc.Error(request.Id, McpConstants.InternalError, ex.Message));
+            }
+        }
+
+        /// <summary>
+        /// The <c>server/discover</c> result: supported modern versions, capabilities and identity.
+        /// Legacy revisions are deliberately not listed - a client picks a version from this list for
+        /// per-request use, and the legacy ones only work through <c>initialize</c>.
+        /// </summary>
+        private JsonObject Discover()
+        {
+            var versions = new JsonArray();
+            foreach (var version in McpConstants.ModernProtocolVersions)
+            {
+                versions.Add(version);
+            }
+
+            var result = new JsonObject
+            {
+                ["supportedVersions"] = versions,
+                ["capabilities"] = new JsonObject
+                {
+                    ["tools"] = new JsonObject { ["listChanged"] = false },
+                },
+            };
+
+            if (!string.IsNullOrEmpty(_options.Instructions))
+            {
+                result["instructions"] = _options.Instructions;
+            }
+
+            return Cacheable(Modern(result));
+        }
+
+        /// <summary>Stamps the fields revision 2026-07-28 requires on every result.</summary>
+        private JsonObject Modern(JsonObject result)
+        {
+            result["resultType"] = "complete";
+            result["_meta"] = new JsonObject
+            {
+                [McpConstants.ServerInfoMetaKey] = new JsonObject
+                {
+                    ["name"] = _options.ServerName ?? "nabu-mcp",
+                    ["version"] = _options.ServerVersion ?? "1.0.0",
+                },
+            };
+
+            return result;
+        }
+
+        /// <summary>
+        /// Stamps the <c>CacheableResult</c> fields. The scope is private because what a caller is
+        /// shown can depend on its credentials (<see cref="NabuMcpOptions.ToolVisibility"/>), so a
+        /// shared cache must never serve one caller's view to another.
+        /// </summary>
+        private JsonObject Cacheable(JsonObject result)
+        {
+            result["ttlMs"] = _options.CacheTtlMilliseconds;
+            result["cacheScope"] = "private";
+            return result;
+        }
+
         private JsonObject Initialize(JsonNode? parameters)
         {
             var requested = parameters?["protocolVersion"]?.GetValue<string>();
@@ -306,6 +432,7 @@ namespace Nabu.Mcp.AspNetCore.Server
             switch (method)
             {
                 case "initialize":
+                case "server/discover":
                 case "ping":
                 case "tools/list":
                 case "resources/list":
@@ -483,6 +610,28 @@ namespace Nabu.Mcp.AspNetCore.Server
         public McpInvalidRequestException(string message)
             : base(message)
         {
+        }
+    }
+
+    /// <summary>
+    /// A response produced under revision 2026-07-28 semantics, where some JSON-RPC errors are
+    /// paired with a specific HTTP status code by the transport.
+    /// </summary>
+    public readonly struct ModernMcpResponse
+    {
+        public ModernMcpResponse(JsonNode body, int statusCode)
+        {
+            Body = body;
+            StatusCode = statusCode;
+        }
+
+        public JsonNode Body { get; }
+
+        public int StatusCode { get; }
+
+        public static ModernMcpResponse Ok(JsonNode body)
+        {
+            return new ModernMcpResponse(body, StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Nabu.Mcp.ModelContextProtocol/Nabu.Mcp.ModelContextProtocol.csproj
+++ b/src/Nabu.Mcp.ModelContextProtocol/Nabu.Mcp.ModelContextProtocol.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--
+      net8.0+ only: the official ModelContextProtocol.AspNetCore SDK does not target
+      netstandard2.0. Apps on older frameworks keep using Nabu's built-in protocol layer,
+      which is exactly why the built-in layer exists.
+    -->
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <RootNamespace>Nabu.Mcp.ModelContextProtocol</RootNamespace>
+    <AssemblyName>Nabu.Mcp.ModelContextProtocol</AssemblyName>
+    <PackageId>Nabu.Mcp.ModelContextProtocol</PackageId>
+    <Title>Nabu.NET - official MCP C# SDK protocol adapter</Title>
+    <Description>
+      Serves Nabu's controller-derived MCP tools through the official ModelContextProtocol C# SDK.
+      Add UseOfficialMcpProtocol() after AddNabuMcp() and the wire protocol - transport, sessions,
+      protocol versions - is handled by the official SDK, while Nabu keeps doing controller
+      discovery, schema generation, authorization-aware visibility and pipeline replay.
+    </Description>
+    <PackageTags>mcp;model-context-protocol;aspnetcore;webapi;ai;llm;tools</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\LICENSE" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.1.0" />
+    <ProjectReference Include="..\Nabu.Mcp.AspNetCore\Nabu.Mcp.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nabu.Mcp.ModelContextProtocol/NabuMcpOfficialProtocolExtensions.cs
+++ b/src/Nabu.Mcp.ModelContextProtocol/NabuMcpOfficialProtocolExtensions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Nabu.Mcp.AspNetCore;
+using Nabu.Mcp.AspNetCore.Server;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>Registration for serving Nabu's tools through the official MCP C# SDK.</summary>
+    public static class NabuMcpOfficialProtocolExtensions
+    {
+        /// <summary>
+        /// Replaces Nabu's built-in MCP protocol layer with the official
+        /// <c>ModelContextProtocol</c> SDK. Call it after <c>AddNabuMcp()</c>:
+        /// <code>
+        /// services.AddNabuMcp().UseOfficialMcpProtocol();
+        /// </code>
+        /// <c>app.UseNabuMcp()</c> then mounts the SDK's Streamable HTTP endpoint at the
+        /// configured path instead of the built-in middleware. The SDK owns the wire protocol -
+        /// transport, sessions, protocol revisions - while Nabu keeps doing controller discovery,
+        /// schema generation, authorization-aware tool visibility and pipeline replay.
+        /// </summary>
+        /// <remarks>
+        /// The transport defaults to stateless mode, matching Nabu's own design: any request can
+        /// land on any server instance. Opt back into the SDK's session-tracking via
+        /// <paramref name="configureTransport"/> if a deployment needs it.
+        /// <see cref="NabuMcpOptions.RequireAuthorization"/> with
+        /// <see cref="McpAnonymousAccess.None"/> is honoured by requiring authorization on the
+        /// mapped endpoint; the partial <see cref="NabuMcpOptions.AnonymousAccess"/> modes leave
+        /// the endpoint itself anonymous, and every tool call is still authorized by the
+        /// application's own pipeline when it is replayed.
+        /// </remarks>
+        /// <param name="services">The service collection <c>AddNabuMcp()</c> was called on.</param>
+        /// <param name="configureTransport">Optional adjustments to the SDK's HTTP transport.</param>
+        public static IServiceCollection UseOfficialMcpProtocol(
+            this IServiceCollection services,
+            Action<HttpServerTransportOptions>? configureTransport = null)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (!services.Any(descriptor => descriptor.ServiceType == typeof(McpPipelineProvider)))
+            {
+                throw new InvalidOperationException(
+                    "UseOfficialMcpProtocol() must be called after AddNabuMcp() on the same service collection.");
+            }
+
+            services.AddHttpContextAccessor();
+            services.TryAddSingleton<Nabu.Mcp.ModelContextProtocol.NabuOfficialMcpBridge>();
+            services.TryAddSingleton<INabuMcpProtocolMount, Nabu.Mcp.ModelContextProtocol.OfficialMcpProtocolMount>();
+
+            services.AddMcpServer()
+                .WithHttpTransport(transport =>
+                {
+                    transport.Stateless = true;
+                    configureTransport?.Invoke(transport);
+                })
+                .WithListToolsHandler((context, cancellationToken) =>
+                    Bridge(context).ListToolsAsync(cancellationToken))
+                .WithCallToolHandler((context, cancellationToken) =>
+                    Bridge(context).CallToolAsync(context.Params!, cancellationToken));
+
+            services.AddOptions<McpServerOptions>().Configure<IOptions<NabuMcpOptions>>((mcpOptions, nabuOptions) =>
+            {
+                var nabu = nabuOptions.Value;
+                mcpOptions.ServerInfo = new Implementation
+                {
+                    Name = nabu.ServerName ?? "nabu-mcp",
+                    Version = nabu.ServerVersion ?? "1.0.0",
+                };
+
+                if (!string.IsNullOrEmpty(nabu.Instructions))
+                {
+                    mcpOptions.ServerInstructions = nabu.Instructions;
+                }
+            });
+
+            return services;
+        }
+
+        private static Nabu.Mcp.ModelContextProtocol.NabuOfficialMcpBridge Bridge(MessageContext context)
+        {
+            var provider = context.Services ?? context.Server.Services;
+            if (provider == null)
+            {
+                throw new InvalidOperationException(
+                    "The MCP request context carries no service provider; the Nabu bridge cannot resolve its services.");
+            }
+
+            return provider.GetRequiredService<Nabu.Mcp.ModelContextProtocol.NabuOfficialMcpBridge>();
+        }
+    }
+}

--- a/src/Nabu.Mcp.ModelContextProtocol/NabuOfficialMcpBridge.cs
+++ b/src/Nabu.Mcp.ModelContextProtocol/NabuOfficialMcpBridge.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using Nabu.Mcp.AspNetCore;
+using Nabu.Mcp.AspNetCore.Discovery;
+using Nabu.Mcp.AspNetCore.Execution;
+using NabuRequestHandler = Nabu.Mcp.AspNetCore.Server.McpRequestHandler;
+
+namespace Nabu.Mcp.ModelContextProtocol
+{
+    /// <summary>
+    /// Serves the official SDK's tool handlers from Nabu's registry and pipeline replay. The SDK
+    /// owns the wire protocol; this type owns the semantics - which tools this caller is shown,
+    /// and how a call becomes a replayed HTTP request.
+    /// </summary>
+    internal sealed class NabuOfficialMcpBridge
+    {
+        private readonly NabuRequestHandler _handler;
+        private readonly IMcpToolRegistry _registry;
+        private readonly IMcpToolInvoker _invoker;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly NabuMcpOptions _options;
+
+        public NabuOfficialMcpBridge(
+            NabuRequestHandler handler,
+            IMcpToolRegistry registry,
+            IMcpToolInvoker invoker,
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<NabuMcpOptions> options)
+        {
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            _invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            _options = (options ?? throw new ArgumentNullException(nameof(options))).Value;
+        }
+
+        public async ValueTask<ListToolsResult> ListToolsAsync(CancellationToken cancellationToken)
+        {
+            var httpContext = RequireHttpContext();
+
+            // Reuses the built-in listing so authorization-aware visibility behaves identically
+            // on both protocol layers.
+            var payload = await _handler.ListToolsAsync(httpContext, cancellationToken).ConfigureAwait(false);
+
+            var result = Deserialize<ListToolsResult>(payload);
+            result.TimeToLive = TimeSpan.FromMilliseconds(_options.CacheTtlMilliseconds);
+            result.CacheScope = CacheScope.Private;
+            return result;
+        }
+
+        public async ValueTask<CallToolResult> CallToolAsync(CallToolRequestParams parameters, CancellationToken cancellationToken)
+        {
+            if (parameters == null || string.IsNullOrEmpty(parameters.Name))
+            {
+                throw new McpException("The 'name' parameter is required for tools/call.");
+            }
+
+            var httpContext = RequireHttpContext();
+
+            McpToolDescriptor? tool;
+            if (!_registry.TryGetTool(parameters.Name, out tool))
+            {
+                throw new McpException("Unknown tool '" + parameters.Name + "'.");
+            }
+
+            JsonObject? arguments = null;
+            if (parameters.Arguments != null)
+            {
+                arguments = new JsonObject();
+                foreach (var argument in parameters.Arguments)
+                {
+                    arguments[argument.Key] = JsonNode.Parse(argument.Value.GetRawText());
+                }
+            }
+
+            McpToolInvocationResult invocation;
+            try
+            {
+                invocation = await _invoker.InvokeAsync(tool!, arguments, httpContext, cancellationToken).ConfigureAwait(false);
+            }
+            catch (McpArgumentException ex)
+            {
+                throw new McpException(ex.Message);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Failures inside the tool surface as isError content so the model can react,
+                // exactly as on the built-in protocol layer.
+                return Deserialize<CallToolResult>(NabuRequestHandler.ToolError("The tool failed to execute: " + ex.Message));
+            }
+
+            return Deserialize<CallToolResult>(_handler.BuildToolResult(tool!, invocation));
+        }
+
+        private HttpContext RequireHttpContext()
+        {
+            return _httpContextAccessor.HttpContext ?? throw new InvalidOperationException(
+                "Nabu's tools replay the application's own HTTP pipeline and need the current HttpContext, " +
+                "so the official-protocol bridge can only serve the HTTP transport.");
+        }
+
+        private static T Deserialize<T>(JsonObject payload)
+        {
+            return JsonSerializer.Deserialize<T>(payload, McpJsonUtilities.DefaultOptions)!;
+        }
+    }
+}

--- a/src/Nabu.Mcp.ModelContextProtocol/OfficialMcpProtocolMount.cs
+++ b/src/Nabu.Mcp.ModelContextProtocol/OfficialMcpProtocolMount.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nabu.Mcp.AspNetCore;
+using Nabu.Mcp.AspNetCore.Server;
+
+namespace Nabu.Mcp.ModelContextProtocol
+{
+    /// <summary>
+    /// Mounts the official SDK's Streamable HTTP endpoint where <c>UseNabuMcp()</c> would have
+    /// mounted the built-in middleware, so switching protocol layers does not change how an
+    /// application wires its pipeline.
+    /// </summary>
+    internal sealed class OfficialMcpProtocolMount : INabuMcpProtocolMount
+    {
+        public void Mount(IApplicationBuilder app, string path)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (app is IEndpointRouteBuilder endpoints)
+            {
+                // Minimal hosting: WebApplication is its own route builder, so the endpoint joins
+                // the application's routing directly.
+                Map(endpoints, path, app.ApplicationServices);
+                return;
+            }
+
+            // Startup-style pipelines: mount a routing scope of our own at this position, which
+            // keeps the contract that UseNabuMcp() serves MCP from wherever it was placed.
+            app.UseRouting();
+            app.UseEndpoints(builder => Map(builder, path, app.ApplicationServices));
+        }
+
+        private static void Map(IEndpointRouteBuilder endpoints, string path, IServiceProvider services)
+        {
+            var endpoint = endpoints.MapMcp(path);
+
+            var options = services.GetRequiredService<IOptions<NabuMcpOptions>>().Value;
+            if (options.RequireAuthorization && options.AnonymousAccess == McpAnonymousAccess.None)
+            {
+                if (string.IsNullOrEmpty(options.AuthorizationPolicy))
+                {
+                    endpoint.RequireAuthorization();
+                }
+                else
+                {
+                    endpoint.RequireAuthorization(options.AuthorizationPolicy!);
+                }
+            }
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/ModernProtocolTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/ModernProtocolTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// Protocol revision 2026-07-28: no handshake, no sessions, the version and capabilities
+    /// declared in <c>_meta</c> on every request and mirrored into HTTP headers.
+    /// </summary>
+    [Collection(McpTestCollection.Name)]
+    public class ModernProtocolTests
+    {
+        private const string Version = "2026-07-28";
+
+        private readonly McpTestFixture _fixture;
+        private int _nextId = 100;
+
+        public ModernProtocolTests(McpTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        private JsonObject BuildRequest(string method, JsonObject? parameters = null, string? version = Version)
+        {
+            parameters ??= new JsonObject();
+            if (version != null)
+            {
+                parameters["_meta"] = new JsonObject
+                {
+                    ["io.modelcontextprotocol/protocolVersion"] = version,
+                    ["io.modelcontextprotocol/clientCapabilities"] = new JsonObject(),
+                    ["io.modelcontextprotocol/clientInfo"] = new JsonObject
+                    {
+                        ["name"] = "nabu-tests",
+                        ["version"] = "1.0.0",
+                    },
+                };
+            }
+
+            return new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = System.Threading.Interlocked.Increment(ref _nextId),
+                ["method"] = method,
+                ["params"] = parameters,
+            };
+        }
+
+        private async Task<HttpResponseMessage> PostAsync(
+            JsonObject request,
+            AuthenticationHeaderValue? token,
+            string? versionHeader,
+            string? methodHeader,
+            string? nameHeader = null)
+        {
+            var client = _fixture.CreateClient();
+            client.DefaultRequestHeaders.Authorization = token;
+
+            var message = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+            {
+                Content = new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json"),
+            };
+
+            if (versionHeader != null)
+            {
+                message.Headers.TryAddWithoutValidation("MCP-Protocol-Version", versionHeader);
+            }
+
+            if (methodHeader != null)
+            {
+                message.Headers.TryAddWithoutValidation("Mcp-Method", methodHeader);
+            }
+
+            if (nameHeader != null)
+            {
+                message.Headers.TryAddWithoutValidation("Mcp-Name", nameHeader);
+            }
+
+            return await client.SendAsync(message);
+        }
+
+        private async Task<HttpResponseMessage> PostConformingAsync(
+            JsonObject request,
+            AuthenticationHeaderValue? token,
+            string? nameHeader = null)
+        {
+            return await PostAsync(
+                request,
+                token,
+                request["params"]!["_meta"]?["io.modelcontextprotocol/protocolVersion"]?.GetValue<string>(),
+                request["method"]!.GetValue<string>(),
+                nameHeader);
+        }
+
+        private static async Task<JsonObject> BodyOf(HttpResponseMessage response)
+        {
+            return JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        }
+
+        [Fact]
+        public async Task Server_discover_reports_versions_capabilities_and_identity()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            using var response = await PostConformingAsync(BuildRequest("server/discover"), token);
+            var result = (await BodyOf(response))["result"]!;
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("complete", result["resultType"]!.GetValue<string>());
+            Assert.Contains(Version, result["supportedVersions"]!.AsArray().GetValues<string>());
+            Assert.NotNull(result["capabilities"]!["tools"]);
+            Assert.Equal(
+                "nabu-todo-sample",
+                result["_meta"]!["io.modelcontextprotocol/serverInfo"]!["name"]!.GetValue<string>());
+            Assert.True(result["ttlMs"]!.GetValue<int>() > 0);
+            Assert.NotNull(result["cacheScope"]);
+        }
+
+        [Fact]
+        public async Task Modern_tools_list_carries_the_cacheable_result_fields()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            using var response = await PostConformingAsync(BuildRequest("tools/list"), token);
+            var result = (await BodyOf(response))["result"]!;
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("complete", result["resultType"]!.GetValue<string>());
+            Assert.True(result["tools"]!.AsArray().Count > 0);
+            Assert.True(result["ttlMs"]!.GetValue<int>() > 0);
+            Assert.Equal("private", result["cacheScope"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task Modern_tools_call_executes_the_action_and_stamps_the_result()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var request = BuildRequest(
+                "tools/call",
+                new JsonObject { ["name"] = "todos_list", ["arguments"] = new JsonObject() });
+
+            using var response = await PostConformingAsync(request, token, nameHeader: "todos_list");
+            var result = (await BodyOf(response))["result"]!.AsObject();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("complete", result["resultType"]!.GetValue<string>());
+            Assert.False(McpTestFixture.IsError(result));
+            Assert.NotNull(result["_meta"]!["io.modelcontextprotocol/serverInfo"]);
+        }
+
+        [Fact]
+        public async Task Modern_requests_are_not_answered_with_a_session_id()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            using var response = await PostConformingAsync(BuildRequest("server/discover"), token);
+
+            Assert.False(response.Headers.Contains("Mcp-Session-Id"));
+        }
+
+        [Fact]
+        public async Task An_unsupported_version_is_rejected_with_the_supported_list()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            using var response = await PostConformingAsync(BuildRequest("tools/list", version: "2025-06-18"), token);
+            var error = (await BodyOf(response))["error"]!;
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(-32022, error["code"]!.GetValue<int>());
+            Assert.Equal("2025-06-18", error["data"]!["requested"]!.GetValue<string>());
+            Assert.Contains(Version, error["data"]!["supported"]!.AsArray().GetValues<string>());
+        }
+
+        [Fact]
+        public async Task A_missing_protocol_version_header_is_a_header_mismatch()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            using var response = await PostAsync(BuildRequest("tools/list"), token, versionHeader: null, methodHeader: "tools/list");
+            var error = (await BodyOf(response))["error"]!;
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(-32020, error["code"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_method_header_that_disagrees_with_the_body_is_a_header_mismatch()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            using var response = await PostAsync(BuildRequest("tools/list"), token, Version, methodHeader: "tools/call");
+            var error = (await BodyOf(response))["error"]!;
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(-32020, error["code"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_tools_call_without_the_name_header_is_a_header_mismatch()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var request = BuildRequest(
+                "tools/call",
+                new JsonObject { ["name"] = "todos_list", ["arguments"] = new JsonObject() });
+
+            using var response = await PostAsync(request, token, Version, "tools/call", nameHeader: null);
+            var error = (await BodyOf(response))["error"]!;
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(-32020, error["code"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_base64_encoded_name_header_is_decoded_before_comparison()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var request = BuildRequest(
+                "tools/call",
+                new JsonObject { ["name"] = "todos_list", ["arguments"] = new JsonObject() });
+
+            var encoded = "=?base64?" + Convert.ToBase64String(Encoding.UTF8.GetBytes("todos_list")) + "?=";
+            using var response = await PostConformingAsync(request, token, nameHeader: encoded);
+            var result = (await BodyOf(response))["result"]!.AsObject();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(McpTestFixture.IsError(result));
+        }
+
+        [Fact]
+        public async Task Methods_removed_by_the_revision_get_404_with_method_not_found()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            // ping was removed in 2026-07-28; it only exists on the legacy path.
+            using var response = await PostConformingAsync(BuildRequest("ping"), token);
+            var error = (await BodyOf(response))["error"]!;
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal(-32601, error["code"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task Modern_notifications_are_acknowledged_without_a_body()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var notification = BuildRequest("notifications/cancelled");
+            notification.Remove("id");
+
+            using var response = await PostConformingAsync(notification, token);
+
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Legacy_clients_still_negotiate_through_initialize()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            // No _meta declaration anywhere: the request must stay on the initialize/session path.
+            var envelope = await _fixture.RpcAsync(
+                "initialize",
+                new JsonObject { ["protocolVersion"] = "2025-06-18" },
+                token);
+
+            Assert.Equal("2025-06-18", envelope["result"]!["protocolVersion"]!.GetValue<string>());
+            Assert.Null(envelope["result"]!["resultType"]);
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/OfficialProtocolTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/OfficialProtocolTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Nabu.Mcp.AspNetCore;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// The official-SDK protocol layer: <c>UseOfficialMcpProtocol()</c> hands the wire protocol to
+    /// the ModelContextProtocol SDK while Nabu keeps serving discovery, visibility and invocation.
+    /// </summary>
+    public class OfficialProtocolTests
+    {
+        private static IHost CreateServer(Action<NabuMcpOptions>? configure = null, string? mountPath = null)
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services
+                            .AddControllers()
+                            .AddApplicationPart(typeof(ProbeController).Assembly)
+                            .OnlyControllers(typeof(ProbeController));
+
+                        services.AddNabuMcp(options =>
+                        {
+                            options.ExposeAllActions = true;
+                            options.ServerName = "official-probe";
+                            options.ServerVersion = "1.2.3";
+                            configure?.Invoke(options);
+                        }).UseOfficialMcpProtocol();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp(mountPath);
+                        app.UseEndpoints(endpoints => endpoints.MapControllers());
+                    }))
+                .Build();
+
+            host.Start();
+            return host;
+        }
+
+        private static async Task<JsonObject> RpcAsync(IHost server, string method, JsonObject? parameters, string path = "/mcp")
+        {
+            var request = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = method,
+            };
+
+            if (parameters != null)
+            {
+                request["params"] = parameters;
+            }
+
+            using var client = server.GetTestClient();
+            using var message = new HttpRequestMessage(HttpMethod.Post, path)
+            {
+                Content = new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json"),
+            };
+            message.Headers.TryAddWithoutValidation("Accept", "application/json, text/event-stream");
+
+            using var response = await client.SendAsync(message);
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.True(
+                response.IsSuccessStatusCode,
+                method + " at " + path + " answered HTTP " + (int)response.StatusCode + ": " + body);
+
+            return ParseRpcResponse(response.Content.Headers.ContentType?.MediaType, body);
+        }
+
+        /// <summary>The SDK may answer with a bare JSON object or a per-request SSE stream.</summary>
+        private static JsonObject ParseRpcResponse(string? mediaType, string body)
+        {
+            if (mediaType != null && mediaType.Contains("event-stream", StringComparison.OrdinalIgnoreCase))
+            {
+                var data = body
+                    .Split('\n')
+                    .Select(line => line.TrimEnd('\r'))
+                    .Where(line => line.StartsWith("data: ", StringComparison.Ordinal))
+                    .Select(line => line.Substring("data: ".Length))
+                    .First();
+
+                return JsonNode.Parse(data)!.AsObject();
+            }
+
+            return JsonNode.Parse(body)!.AsObject();
+        }
+
+        private static JsonObject InitializeParams()
+        {
+            return new JsonObject
+            {
+                ["protocolVersion"] = "2025-06-18",
+                ["capabilities"] = new JsonObject(),
+                ["clientInfo"] = new JsonObject { ["name"] = "nabu-tests", ["version"] = "1.0.0" },
+            };
+        }
+
+        [Fact]
+        public async Task Initialize_reports_the_identity_configured_through_nabu_options()
+        {
+            using var server = CreateServer();
+
+            var envelope = await RpcAsync(server, "initialize", InitializeParams());
+            var info = envelope["result"]!["serverInfo"]!;
+
+            Assert.Equal("official-probe", info["name"]!.GetValue<string>());
+            Assert.Equal("1.2.3", info["version"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task Tools_discovered_by_nabu_are_listed_through_the_official_sdk()
+        {
+            using var server = CreateServer();
+
+            // No prior initialize on this request: the transport defaults to stateless mode.
+            var envelope = await RpcAsync(server, "tools/list", new JsonObject());
+            var names = envelope["result"]!["tools"]!.AsArray()
+                .Select(tool => tool!["name"]!.GetValue<string>())
+                .ToArray();
+
+            Assert.Contains("probe_echo", names);
+            Assert.Contains("probe_sum", names);
+            Assert.DoesNotContain("probe_hidden", names);
+        }
+
+        [Fact]
+        public async Task Tool_calls_replay_the_application_pipeline()
+        {
+            using var server = CreateServer();
+
+            var envelope = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject
+                {
+                    ["name"] = "probe_echo",
+                    ["arguments"] = new JsonObject { ["value"] = "through-the-sdk" },
+                });
+
+            var result = envelope["result"]!.AsObject();
+            Assert.NotEqual(true, result["isError"]?.GetValue<bool>());
+
+            var text = result["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+            Assert.Equal("through-the-sdk", JsonNode.Parse(text)!["value"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task An_unknown_tool_is_reported_as_an_error()
+        {
+            using var server = CreateServer();
+
+            var envelope = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject { ["name"] = "no_such_tool", ["arguments"] = new JsonObject() });
+
+            // The SDK owns how a handler exception surfaces; depending on version it is either a
+            // JSON-RPC error or an isError tool result. Either way the caller must see a failure
+            // that names the tool.
+            var error = envelope["error"];
+            if (error != null)
+            {
+                Assert.Contains("no_such_tool", error["message"]!.GetValue<string>());
+            }
+            else
+            {
+                var result = envelope["result"]!.AsObject();
+                Assert.True(result["isError"]?.GetValue<bool>() ?? false, "Expected an error, got: " + envelope.ToJsonString());
+                Assert.Contains("no_such_tool", result["content"]!.AsArray()[0]!["text"]!.GetValue<string>());
+            }
+        }
+
+        [Fact]
+        public async Task The_route_passed_to_UseNabuMcp_mounts_the_sdk_endpoint_there()
+        {
+            using var server = CreateServer(mountPath: "/bridge");
+
+            var envelope = await RpcAsync(server, "tools/list", new JsonObject(), path: "/bridge");
+            Assert.NotNull(envelope["result"]!["tools"]);
+
+            using var client = server.GetTestClient();
+            using var message = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+            {
+                Content = new StringContent(
+                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+            message.Headers.TryAddWithoutValidation("Accept", "application/json, text/event-stream");
+
+            using var atDefault = await client.SendAsync(message);
+            Assert.Equal(HttpStatusCode.NotFound, atDefault.StatusCode);
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/StandaloneAppTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/StandaloneAppTests.cs
@@ -179,6 +179,48 @@ namespace Nabu.Mcp.AspNetCore.Tests.Integration
         }
 
         [Fact]
+        public async Task The_path_argument_of_UseNabuMcp_wins_over_the_configured_path()
+        {
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services
+                            .AddControllers()
+                            .AddApplicationPart(typeof(ProbeController).Assembly)
+                            .OnlyControllers(typeof(ProbeController));
+
+                        services.AddNabuMcp(options =>
+                        {
+                            options.ExposeAllActions = true;
+                            options.Path = "/configured";
+                        });
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp("mounted");
+                        app.UseEndpoints(endpoints => endpoints.MapControllers());
+                    }))
+                .Build();
+
+            host.Start();
+            using var server = host;
+            using var client = server.GetTestClient();
+
+            using var atConfigured = await client.PostAsync(
+                "/configured",
+                new StringContent("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.NotFound, atConfigured.StatusCode);
+
+            using var atMounted = await client.PostAsync(
+                "/mounted",
+                new StringContent("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.OK, atMounted.StatusCode);
+        }
+
+        [Fact]
         public async Task Header_parameters_are_hidden_by_default()
         {
             using var server = CreateServer(options => options.ExposeAllActions = true);

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Nabu.Mcp.AspNetCore.Tests.csproj
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Nabu.Mcp.AspNetCore.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Nabu.Mcp.AspNetCore\Nabu.Mcp.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Nabu.Mcp.ModelContextProtocol\Nabu.Mcp.ModelContextProtocol.csproj" />
     <ProjectReference Include="..\..\samples\Nabu.Sample.TodoApi\Nabu.Sample.TodoApi.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
…dshake

The 2026-07-28 revision made MCP stateless: initialize/initialized and Mcp-Session-Id are gone, and every request declares its protocol version and client capabilities in _meta. This server was already stateless, so the change is a second protocol surface rather than a redesign.

The endpoint is now dual-era. A request that declares a protocol version in _meta (or calls server/discover) is served under 2026-07-28 semantics:

- server/discover advertises supported versions, capabilities, identity and instructions.
- The mirrored headers (MCP-Protocol-Version, Mcp-Method, Mcp-Name) are validated against the body, including the Base64 sentinel encoding, and a disagreement is rejected with 400 / -32020 (HeaderMismatch).
- An unsupported declared version is rejected with 400 / -32022 (UnsupportedProtocolVersion) listing the supported versions.
- Results are stamped with resultType, the server's identity in _meta, and ttlMs/cacheScope (new CacheTtlMilliseconds option) on cacheable results. cacheScope is private because tool visibility can depend on the caller's credentials.
- Unknown methods pair 404 with -32601, and no session id is minted.

Requests without the _meta declaration stay on the legacy initialize path (2025-06-18 / 2025-03-26 / 2024-11-05) exactly as before.


Claude-Session: https://claude.ai/code/session_01J6PHEnpwpFRCnXKsgg1c7p