### PR TITLE
Add JWT auth and per-identity tool exposure to official SDK sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,11 @@ partial `AnonymousAccess` modes leave the endpoint anonymous and rely on the rep
 to authorize each call.
 
 `samples/Nabu.Sample.OfficialSdk` is a complete runnable example: a small book-catalog API
-published through the official SDK on a custom route (`app.UseNabuMcp("/books/mcp")`).
+published through the official SDK on a custom route (`app.UseNabuMcp("/books/mcp")`). It carries
+the same JWT setup and per-caller tool exposure as the Todo sample - `books_search` and
+`books_get` are anonymous, `books_add` requires a signed-in caller, and `books_remove` appears
+only for an administrator - showing that the authorization story is identical on both protocol
+layers.
 
 ## Target frameworks
 
@@ -544,28 +548,34 @@ dotnet run --project samples/Nabu.Sample.TodoApi
 
 ## Trying it with MCP Inspector
 
-`docker-compose.yml` runs the sample together with the official
+`docker-compose.yml` runs both samples together with the official
 [MCP Inspector](https://github.com/modelcontextprotocol/inspector), preconfigured to demonstrate the
-per-caller tool exposure above:
+per-caller tool exposure above on both protocol layers:
 
 ```bash
 docker compose up --build
 # then open http://localhost:6274?MCP_INSPECTOR_API_TOKEN=nabu-local-dev
 ```
 
-A one-shot init container signs in as `alice` and `root` and writes an Inspector config with three
-connections to the same endpoint - `nabu-anonymous`, `nabu-alice-user` and `nabu-root-admin` - so
-switching between them in the UI shows the tool list grow from the 4 anonymous tools to alice's 10
-to root's 11 (only root gets `todos_delete`). The API itself is published on
-`http://localhost:5080/mcp` (5080 rather than 5000, which macOS AirPlay occupies).
+A one-shot init container signs in as `alice` and `root` on both samples and writes an Inspector
+config with three connections per sample, each to the same endpoint. For the Todo sample -
+`todo-anonymous`, `todo-alice-user` and `todo-root-admin` - switching between them in the UI shows
+the tool list grow from the 4 anonymous tools to alice's 10 to root's 11 (only root gets
+`todos_delete`). For the book catalog served through the official SDK - `books-anonymous`,
+`books-alice-user` and `books-root-admin` - the list grows from the 2 search tools to alice's 3
+(`books_add`) to root's 4 (`books_remove`). The Todo API is published on
+`http://localhost:5080/mcp` (5080 rather than 5000, which macOS AirPlay occupies) and the
+book catalog on `http://localhost:5081/books/mcp`.
 
 The same comparison from the terminal, via the Inspector CLI:
 
 ```bash
 docker compose run --rm inspector --cli --config /shared/mcp-servers.json \
-  --server nabu-anonymous --method tools/list
+  --server todo-anonymous --method tools/list
 docker compose run --rm inspector --cli --config /shared/mcp-servers.json \
-  --server nabu-root-admin --method tools/list
+  --server todo-root-admin --method tools/list
+docker compose run --rm inspector --cli --config /shared/mcp-servers.json \
+  --server books-root-admin --method tools/list
 ```
 
 The demo tokens live for 24 hours; `docker compose up` again regenerates them.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,23 @@
-# Runs the sample TodoApi and MCP Inspector together to showcase Nabu's
-# per-identity tool exposure:
+# Runs both samples and MCP Inspector together to showcase Nabu's
+# per-identity tool exposure on both protocol layers:
 #
 #   docker compose up --build
 #   open http://localhost:6274?MCP_INSPECTOR_API_TOKEN=nabu-local-dev
 #
-# The Inspector's server list has three connections to the SAME endpoint:
-#   nabu-anonymous   -> weather tools + todos_get_priorities only
-#   nabu-alice-user  -> + alice's todo tools
-#   nabu-root-admin  -> + todos_delete (admin-only)
+# The Inspector's server list has three connections per sample, each hitting
+# the SAME endpoint:
+#   todo-anonymous    -> weather tools + todos_get_priorities only
+#   todo-alice-user   -> + alice's todo tools
+#   todo-root-admin   -> + todos_delete (admin-only)
+#   books-anonymous   -> books_search + books_get only
+#   books-alice-user  -> + books_add
+#   books-root-admin  -> + books_remove (admin-only)
 #
 # The same comparison, scriptable:
 #   docker compose run --rm inspector --cli --config /shared/mcp-servers.json \
-#     --server nabu-anonymous --method tools/list
+#     --server todo-anonymous --method tools/list
 #   docker compose run --rm inspector --cli --config /shared/mcp-servers.json \
-#     --server nabu-root-admin --method tools/list
+#     --server books-root-admin --method tools/list
 services:
   todo-api:
     build:
@@ -31,8 +35,25 @@ services:
       timeout: 3s
       retries: 30
 
-  # One-shot: logs in as alice and root, writes the Inspector catalog with
-  # anonymous / alice / root connections into the shared volume.
+  # The same tools-per-identity demo, served through the official
+  # ModelContextProtocol C# SDK instead of Nabu's built-in protocol layer.
+  official-sdk-api:
+    build:
+      context: .
+      dockerfile: samples/Nabu.Sample.OfficialSdk/Dockerfile
+    ports:
+      - "5081:8080"
+    environment:
+      Jwt__LifetimeMinutes: "1440"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8080"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  # One-shot: logs in as alice and root on both samples, writes the Inspector
+  # catalog with anonymous / alice / root connections per sample into the
+  # shared volume.
   inspector-config:
     image: curlimages/curl:latest
     # The curl image defaults to a non-root user that cannot write to the
@@ -44,6 +65,8 @@ services:
     entrypoint: ["/bin/sh", "/generate-inspector-config.sh"]
     depends_on:
       todo-api:
+        condition: service_healthy
+      official-sdk-api:
         condition: service_healthy
 
   inspector:

--- a/docker/generate-inspector-config.sh
+++ b/docker/generate-inspector-config.sh
@@ -1,49 +1,75 @@
 #!/bin/sh
-# Logs into the sample as alice (user) and root (admin) and writes an MCP
-# Inspector catalog with three connections to the same endpoint - anonymous,
-# alice, and root - so the tool list can be compared per identity.
+# Logs into both samples as alice (user) and root (admin) and writes an MCP
+# Inspector catalog with three connections per sample to the same endpoint -
+# anonymous, alice, and root - so the tool list can be compared per identity
+# on both protocol layers.
 set -eu
 
-API=${API_URL:-http://todo-api:8080}
+TODO_API=${TODO_API_URL:-http://todo-api:8080}
+BOOKS_API=${BOOKS_API_URL:-http://official-sdk-api:8080}
 OUT=${OUT_FILE:-/shared/mcp-servers.json}
 
-echo "Waiting for $API ..."
-until [ "$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/api/auth/login" \
-      -H 'Content-Type: application/json' \
-      -d '{"username":"alice","password":"password"}')" = "200" ]; do
-  sleep 1
-done
+# $1: base URL of the API to wait for.
+wait_for_login() {
+  echo "Waiting for $1 ..."
+  until [ "$(curl -s -o /dev/null -w '%{http_code}' -X POST "$1/api/auth/login" \
+        -H 'Content-Type: application/json' \
+        -d '{"username":"alice","password":"password"}')" = "200" ]; do
+    sleep 1
+  done
+}
 
+# $1: base URL, $2: username. Each sample signs its own tokens, so log in per API.
 token() {
-  curl -sf -X POST "$API/api/auth/login" \
+  curl -sf -X POST "$1/api/auth/login" \
     -H "Content-Type: application/json" \
-    -d "{\"username\":\"$1\",\"password\":\"password\"}" \
+    -d "{\"username\":\"$2\",\"password\":\"password\"}" \
     | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p'
 }
 
-ALICE=$(token alice)
-ROOT=$(token root)
-[ -n "$ALICE" ] && [ -n "$ROOT" ] || { echo "Failed to obtain tokens" >&2; exit 1; }
+wait_for_login "$TODO_API"
+wait_for_login "$BOOKS_API"
+
+TODO_ALICE=$(token "$TODO_API" alice)
+TODO_ROOT=$(token "$TODO_API" root)
+BOOKS_ALICE=$(token "$BOOKS_API" alice)
+BOOKS_ROOT=$(token "$BOOKS_API" root)
+[ -n "$TODO_ALICE" ] && [ -n "$TODO_ROOT" ] && [ -n "$BOOKS_ALICE" ] && [ -n "$BOOKS_ROOT" ] \
+  || { echo "Failed to obtain tokens" >&2; exit 1; }
 
 cat > "$OUT" <<EOF
 {
   "mcpServers": {
-    "nabu-anonymous": {
+    "todo-anonymous": {
       "type": "http",
-      "url": "$API/mcp"
+      "url": "$TODO_API/mcp"
     },
-    "nabu-alice-user": {
+    "todo-alice-user": {
       "type": "http",
-      "url": "$API/mcp",
-      "headers": { "Authorization": "Bearer $ALICE" }
+      "url": "$TODO_API/mcp",
+      "headers": { "Authorization": "Bearer $TODO_ALICE" }
     },
-    "nabu-root-admin": {
+    "todo-root-admin": {
       "type": "http",
-      "url": "$API/mcp",
-      "headers": { "Authorization": "Bearer $ROOT" }
+      "url": "$TODO_API/mcp",
+      "headers": { "Authorization": "Bearer $TODO_ROOT" }
+    },
+    "books-anonymous": {
+      "type": "http",
+      "url": "$BOOKS_API/books/mcp"
+    },
+    "books-alice-user": {
+      "type": "http",
+      "url": "$BOOKS_API/books/mcp",
+      "headers": { "Authorization": "Bearer $BOOKS_ALICE" }
+    },
+    "books-root-admin": {
+      "type": "http",
+      "url": "$BOOKS_API/books/mcp",
+      "headers": { "Authorization": "Bearer $BOOKS_ROOT" }
     }
   }
 }
 EOF
 
-echo "Wrote $OUT (anonymous / alice / root)"
+echo "Wrote $OUT (anonymous / alice / root for todo and books)"

--- a/samples/Nabu.Sample.OfficialSdk/Controllers/AuthController.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Controllers/AuthController.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Nabu.Mcp.AspNetCore;
+using Nabu.Sample.OfficialSdk.Models;
+using Nabu.Sample.OfficialSdk.Services;
+
+namespace Nabu.Sample.OfficialSdk.Controllers
+{
+    /// <summary>
+    /// Issues the tokens used by the rest of the sample. Credential handling is never exposed as an MCP
+    /// tool, so the whole controller carries <see cref="McpIgnoreAttribute"/>.
+    /// </summary>
+    [ApiController]
+    [Route("api/auth")]
+    [AllowAnonymous]
+    [McpIgnore]
+    public class AuthController : ControllerBase
+    {
+        // Sample-only accounts. A real application would look users up in a store.
+        private static readonly Dictionary<string, string[]> Accounts = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["alice"] = new[] { "user" },
+            ["root"] = new[] { "user", "admin" },
+        };
+
+        private readonly TokenService _tokens;
+
+        public AuthController(TokenService tokens)
+        {
+            _tokens = tokens;
+        }
+
+        /// <summary>Exchanges sample credentials for a bearer token.</summary>
+        [HttpPost("login")]
+        public ActionResult<LoginResponse> Login([FromBody] LoginRequest request)
+        {
+            string[]? roles;
+            if (!Accounts.TryGetValue(request.Username, out roles) || request.Password != "password")
+            {
+                return Unauthorized(new { message = "Invalid username or password." });
+            }
+
+            var issued = _tokens.Issue(request.Username, roles!);
+
+            return Ok(new LoginResponse
+            {
+                AccessToken = issued.Token,
+                ExpiresInSeconds = issued.ExpiresInSeconds,
+            });
+        }
+    }
+}

--- a/samples/Nabu.Sample.OfficialSdk/Controllers/BooksController.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Controllers/BooksController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nabu.Mcp.AspNetCore;
 using Nabu.Sample.OfficialSdk.Models;
@@ -6,9 +7,17 @@ using Nabu.Sample.OfficialSdk.Services;
 
 namespace Nabu.Sample.OfficialSdk.Controllers
 {
-    /// <summary>A small book catalog exposed both as a REST API and as MCP tools.</summary>
+    /// <summary>
+    /// A small book catalog exposed both as a REST API and as MCP tools. The controller requires a
+    /// signed-in caller; the read-only actions opt out with <see cref="AllowAnonymousAttribute"/>, so
+    /// an anonymous MCP client is shown (and can call) just the search tools, a signed-in user can
+    /// also add books, and only an administrator sees <c>books_remove</c>. The authorization rules
+    /// are enforced for tool calls exactly as for direct HTTP requests - the official SDK protocol
+    /// layer changes nothing about that.
+    /// </summary>
     [ApiController]
     [Route("api/books")]
+    [Authorize]
     public class BooksController : ControllerBase
     {
         private readonly IBookCatalog _catalog;
@@ -21,6 +30,7 @@ namespace Nabu.Sample.OfficialSdk.Controllers
         /// <summary>Searches the catalog by title or author.</summary>
         /// <param name="query">Text to look for; omit it to list every book.</param>
         [HttpGet]
+        [AllowAnonymous]
         [McpTool("books_search", Description = "Search the book catalog by title or author.", ReadOnly = true)]
         public ActionResult<IReadOnlyList<Book>> Search([FromQuery] string? query)
         {
@@ -30,6 +40,7 @@ namespace Nabu.Sample.OfficialSdk.Controllers
         /// <summary>Fetches one book by its id.</summary>
         /// <param name="id">Identifier returned by a search.</param>
         [HttpGet("{id:int}")]
+        [AllowAnonymous]
         [McpTool("books_get", Description = "Fetch a single book by id.", ReadOnly = true)]
         public ActionResult<Book> Get(int id)
         {
@@ -37,7 +48,7 @@ namespace Nabu.Sample.OfficialSdk.Controllers
             return book == null ? NotFound() : Ok(book);
         }
 
-        /// <summary>Adds a book to the catalog.</summary>
+        /// <summary>Adds a book to the catalog. Requires a signed-in caller.</summary>
         /// <param name="request">The book to add.</param>
         [HttpPost]
         [McpTool("books_add", Description = "Add a book to the catalog.")]
@@ -45,6 +56,19 @@ namespace Nabu.Sample.OfficialSdk.Controllers
         {
             var book = _catalog.Add(request.Title, request.Author, request.Year);
             return CreatedAtAction(nameof(Get), new { id = book.Id }, book);
+        }
+
+        /// <summary>
+        /// Permanently removes a book from the catalog. Restricted to administrators, which the MCP
+        /// endpoint honours because the tool call runs through the same authorization pipeline.
+        /// </summary>
+        /// <param name="id">Identifier of the book to remove.</param>
+        [HttpDelete("{id:int}")]
+        [Authorize(Policy = "AdminOnly")]
+        [McpTool("books_remove", Description = "Remove a book from the catalog. Administrators only.")]
+        public IActionResult Remove(int id)
+        {
+            return _catalog.Remove(id) ? NoContent() : NotFound();
         }
     }
 

--- a/samples/Nabu.Sample.OfficialSdk/Dockerfile
+++ b/samples/Nabu.Sample.OfficialSdk/Dockerfile
@@ -1,0 +1,20 @@
+# Build from the repository root so the project references to src/ resolve:
+#   docker build -f samples/Nabu.Sample.OfficialSdk/Dockerfile .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /source
+
+COPY Directory.Build.props ./
+COPY src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj src/Nabu.Mcp.AspNetCore/
+COPY src/Nabu.Mcp.ModelContextProtocol/Nabu.Mcp.ModelContextProtocol.csproj src/Nabu.Mcp.ModelContextProtocol/
+COPY samples/Nabu.Sample.OfficialSdk/Nabu.Sample.OfficialSdk.csproj samples/Nabu.Sample.OfficialSdk/
+RUN dotnet restore samples/Nabu.Sample.OfficialSdk/Nabu.Sample.OfficialSdk.csproj
+
+COPY src/ src/
+COPY samples/ samples/
+RUN dotnet publish samples/Nabu.Sample.OfficialSdk/Nabu.Sample.OfficialSdk.csproj -c Release -o /app --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Nabu.Sample.OfficialSdk.dll"]

--- a/samples/Nabu.Sample.OfficialSdk/Models/AuthModels.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Models/AuthModels.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Nabu.Sample.OfficialSdk.Models
+{
+    /// <summary>Credentials exchanged for an access token.</summary>
+    public class LoginRequest
+    {
+        /// <summary>User login. The sample accepts "alice" (user) and "root" (administrator).</summary>
+        [Required]
+        public string Username { get; set; } = string.Empty;
+
+        /// <summary>Password. Every sample account uses "password".</summary>
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+
+    /// <summary>An issued access token.</summary>
+    public class LoginResponse
+    {
+        public string AccessToken { get; set; } = string.Empty;
+
+        public string TokenType { get; set; } = "Bearer";
+
+        public int ExpiresInSeconds { get; set; }
+    }
+}

--- a/samples/Nabu.Sample.OfficialSdk/Nabu.Sample.OfficialSdk.csproj
+++ b/samples/Nabu.Sample.OfficialSdk/Nabu.Sample.OfficialSdk.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Nabu.Mcp.AspNetCore\Nabu.Mcp.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Nabu.Mcp.ModelContextProtocol\Nabu.Mcp.ModelContextProtocol.csproj" />
   </ItemGroup>

--- a/samples/Nabu.Sample.OfficialSdk/Program.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Program.cs
@@ -1,5 +1,9 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 using Nabu.Mcp.AspNetCore;
 using Nabu.Sample.OfficialSdk.Services;
 
@@ -7,19 +11,61 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddSingleton<IBookCatalog, InMemoryBookCatalog>();
+builder.Services.AddSingleton<TokenService>();
+
+builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));
+var jwt = builder.Configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>() ?? new JwtOptions();
+
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwt.Issuer,
+            ValidAudience = jwt.Audience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.SigningKey)),
+        };
+    });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOnly", policy => policy.RequireRole("admin"));
+});
 
 // ---------------------------------------------------------------------------
 // Nabu discovers the [McpTool] actions, generates their schemas and replays
 // each call through the pipeline - exactly as in the Todo sample. The one
 // difference is UseOfficialMcpProtocol(): the wire protocol (transport,
 // protocol revisions, sessions) is handled by the official ModelContextProtocol
-// C# SDK instead of Nabu's built-in layer.
+// C# SDK instead of Nabu's built-in layer. The authorization options below
+// behave identically on both layers.
 // ---------------------------------------------------------------------------
 builder.Services.AddNabuMcp(options =>
 {
     options.ServerName = "nabu-official-sdk-sample";
     options.ServerVersion = "1.0.0";
-    options.Instructions = "A small book catalog. Search before adding to avoid duplicates.";
+    options.Instructions =
+        "A small book catalog. Search before adding to avoid duplicates. " +
+        "Adding a book requires a signed-in caller; removing one requires an administrator token.";
+
+    // The MCP endpoint requires an authenticated caller. Individual actions are still authorized
+    // independently by their own [Authorize] attributes.
+    options.RequireAuthorization = true;
+
+    // ...except that a client may be added before it has a token. It then sees only the search
+    // tools - Search and Get carry [AllowAnonymous], so those actions are reachable by anyone -
+    // and may call them. books_add and books_remove are neither advertised nor callable until it
+    // signs in; asking for one answers 401, which is the signal a client needs to authenticate.
+    options.AnonymousAccess = McpAnonymousAccess.AnonymousTools;
+
+    // Each caller is advertised what its own credentials reach: anonymous callers see the search
+    // tools, alice can also add books, and only an administrator is shown books_remove.
+    options.ToolVisibility = McpToolVisibility.Authorized;
 })
 .UseOfficialMcpProtocol();
 // The SDK's transport can be tuned through the optional delegate, for example
@@ -28,8 +74,12 @@ builder.Services.AddNabuMcp(options =>
 
 var app = builder.Build();
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 // Same mount point as the built-in layer; the path argument overrides the
-// default /mcp route (options.Path works too, the argument wins).
+// default /mcp route (options.Path works too, the argument wins). Mounted
+// after authentication so the MCP endpoint sees the caller's identity.
 app.UseNabuMcp("/books/mcp");
 
 app.MapControllers();

--- a/samples/Nabu.Sample.OfficialSdk/Services/IBookCatalog.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Services/IBookCatalog.cs
@@ -10,5 +10,7 @@ namespace Nabu.Sample.OfficialSdk.Services
         Book? Get(int id);
 
         Book Add(string title, string author, int year);
+
+        bool Remove(int id);
     }
 }

--- a/samples/Nabu.Sample.OfficialSdk/Services/InMemoryBookCatalog.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Services/InMemoryBookCatalog.cs
@@ -56,5 +56,13 @@ namespace Nabu.Sample.OfficialSdk.Services
                 return book;
             }
         }
+
+        public bool Remove(int id)
+        {
+            lock (_gate)
+            {
+                return _books.RemoveAll(book => book.Id == id) > 0;
+            }
+        }
     }
 }

--- a/samples/Nabu.Sample.OfficialSdk/Services/TokenService.cs
+++ b/samples/Nabu.Sample.OfficialSdk/Services/TokenService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Nabu.Sample.OfficialSdk.Services
+{
+    /// <summary>Settings for the sample's JWT bearer authentication.</summary>
+    public sealed class JwtOptions
+    {
+        public const string SectionName = "Jwt";
+
+        public string Issuer { get; set; } = "nabu-sample";
+
+        public string Audience { get; set; } = "nabu-sample";
+
+        /// <summary>
+        /// Symmetric signing key. The sample ships a development value in appsettings.json; a real
+        /// deployment must supply its own through configuration or a secret store.
+        /// </summary>
+        public string SigningKey { get; set; } = string.Empty;
+
+        public int LifetimeMinutes { get; set; } = 60;
+    }
+
+    /// <summary>Issues the access tokens used by the sample's login endpoint.</summary>
+    public sealed class TokenService
+    {
+        private readonly JwtOptions _options;
+
+        public TokenService(Microsoft.Extensions.Options.IOptions<JwtOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public (string Token, int ExpiresInSeconds) Issue(string username, IEnumerable<string> roles)
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, username),
+                new Claim(ClaimTypes.Name, username),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            };
+
+            foreach (var role in roles)
+            {
+                claims.Add(new Claim(ClaimTypes.Role, role));
+            }
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.SigningKey));
+            var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var expires = DateTime.UtcNow.AddMinutes(_options.LifetimeMinutes);
+
+            var token = new JwtSecurityToken(
+                issuer: _options.Issuer,
+                audience: _options.Audience,
+                claims: claims,
+                notBefore: DateTime.UtcNow,
+                expires: expires,
+                signingCredentials: credentials);
+
+            return (new JwtSecurityTokenHandler().WriteToken(token), _options.LifetimeMinutes * 60);
+        }
+    }
+}

--- a/samples/Nabu.Sample.OfficialSdk/appsettings.json
+++ b/samples/Nabu.Sample.OfficialSdk/appsettings.json
@@ -2,8 +2,15 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Nabu.Mcp.AspNetCore": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Issuer": "nabu-sample",
+    "Audience": "nabu-sample",
+    "SigningKey": "development-only-signing-key-do-not-use-in-production-0123456789",
+    "LifetimeMinutes": 60
+  }
 }


### PR DESCRIPTION
## Summary
Extends the Official SDK sample with JWT-based authentication and per-caller tool visibility, demonstrating that authorization works identically across both Nabu's built-in and official ModelContextProtocol SDK protocol layers.

## Key Changes

- **Authentication & Authorization**: Added JWT bearer token support to the Official SDK sample with `TokenService` and `AuthController`, mirroring the Todo sample's auth setup
  - New `JwtOptions` configuration class for token settings
  - Login endpoint that issues tokens for sample accounts (alice/user, root/admin)
  - Token validation configured in `Program.cs` with issuer, audience, and signing key checks

- **Per-Caller Tool Exposure**: Implemented authorization-based tool visibility in `BooksController`
  - `books_search` and `books_get` marked with `[AllowAnonymous]` for public access
  - `books_add` requires authenticated caller (implicit `[Authorize]` on controller)
  - `books_remove` restricted to admin role via `[Authorize(Policy = "AdminOnly")]`
  - Configured MCP endpoint with `RequireAuthorization = true` and `AnonymousAccess = McpAnonymousTools` to show only reachable tools per caller

- **Infrastructure**: 
  - Added `Dockerfile` for containerized deployment
  - Updated `docker-compose.yml` to run both samples alongside MCP Inspector
  - Modified `generate-inspector-config.sh` to authenticate against both APIs and generate separate connection sets for Todo and Books samples
  - Updated documentation to reflect dual-sample setup

- **Model & Service Updates**:
  - Added `AuthModels.cs` with `LoginRequest`/`LoginResponse` DTOs
  - Extended `IBookCatalog` with `Remove()` method for admin-only deletion
  - Updated `appsettings.json` with JWT configuration

## Implementation Details

The authorization story is now identical on both protocol layers: the same `[Authorize]` and `[AllowAnonymous]` attributes control both REST API access and MCP tool visibility. Tool calls run through the standard ASP.NET Core authorization pipeline, ensuring consistent enforcement whether accessed via HTTP or MCP.

The MCP endpoint is mounted after `app.UseAuthentication()` and `app.UseAuthorization()` so it receives the caller's identity context, enabling the framework to enforce per-action authorization rules transparently.

https://claude.ai/code/session_01Skw3iyHGUepgCUXGUX7Tab