### PR TITLE
Add response capping and protected header enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@
 [![NuGet](https://img.shields.io/nuget/v/Nabu.Mcp.AspNetCore.svg)](https://www.nuget.org/packages/Nabu.Mcp.AspNetCore)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**Expose the ASP.NET Core Web API you already have as MCP tools by adding one attribute.**
+**Turn the ASP.NET Core Web API you already have into an MCP server - without rewriting your API.**
+
+One attribute. Same endpoint. Same authorization. Same validation. Same middleware.
 
 `Nabu.Mcp.AspNetCore` turns existing controller actions into [Model Context Protocol](https://modelcontextprotocol.io)
 tools. It does not ask you to re-declare your endpoints, duplicate validation, or re-implement your
 security model. A tool call is replayed as a real HTTP request through **your application's own
 pipeline**, so authentication, authorization policies, action filters, model binding, model validation,
-exception handlers and every other piece of middleware keep working exactly as they do today.
+exception handlers and every other piece of middleware keep working exactly as they do today. Tool
+visibility can even be evaluated with your application's own authorization policies, so `tools/list`
+shows each caller only the tools it is actually allowed to invoke - see
+[Advertising tools per caller](#advertising-tools-per-caller).
 
 ```csharp
 [HttpGet("{id:guid}")]
@@ -52,9 +57,16 @@ built `RequestDelegate` at the very front of the pipeline. To run a tool it cons
 `HttpContext` for the target route - carrying the caller's identity, forwarded credentials, a fresh DI
 scope and a JSON body built from the tool arguments - and pushes it through that captured pipeline.
 
-The action cannot tell the difference between a tool call and a request from a browser. That is the
-entire design goal, and the test suite asserts it: the same `[Authorize(Policy = "AdminOnly")]` that
-returns 403 over HTTP returns an `isError` tool result over MCP, for the same caller.
+A tool call therefore runs through the same ASP.NET Core application pipeline as a client-issued
+request and preserves standard HTTP application semantics: request and response, connection
+information, request services, cancellation and the caller's identity all behave as they do for a
+real request. The test suite asserts it: the same `[Authorize(Policy = "AdminOnly")]` that returns
+403 over HTTP returns an `isError` tool result over MCP, for the same caller.
+
+What the synthetic request carries is the HTTP *application* surface, not the server transport.
+Middleware that depends on server-level features - client certificates and other TLS features,
+HTTP/2-specific server features, WebSockets, response upgrade, raw transport access - will find them
+absent, exactly as it would behind some reverse proxies. See [Limitations](#limitations).
 
 ## Getting started
 
@@ -304,6 +316,32 @@ Identity reaches the action two ways, which reinforce each other:
 Hop-by-hop and content headers (`Content-Length`, `Transfer-Encoding`, `Accept-Encoding`, `Host`, ...)
 are never forwarded; they are rebuilt for the synthetic request.
 
+**Protected headers.** A model-supplied argument can never override the headers that carry
+credentials or proxy metadata. Even with `ExposeHeaderParameters` on, a tool argument that binds to a
+header in `ProtectedHeaders` - by default `Authorization`, `Cookie`, `Host`, `X-Forwarded-For`,
+`X-Forwarded-Proto` and `X-Forwarded-Host` - is dropped with a warning, and the value forwarded from
+the MCP caller stays in place. Constants pinned by the developer through `ConstantParameters` are
+exempt, because they are developer input rather than model input. Removing a name from the set is the
+explicit opt-in:
+
+```csharp
+options.ProtectedHeaders.Remove("Authorization");   // only if you really mean it
+```
+
+### Recommended production configuration
+
+The defaults are tuned for a first run: the MCP endpoint is anonymous and every discovered tool is
+advertised, while each invocation is still authorized by the application pipeline. That is never an
+authorization bypass - a caller can at most see the names and schemas of tools it cannot invoke - but
+for production deployments, lock the endpoint down and tailor the catalogue to the caller:
+
+```csharp
+options.RequireAuthorization = true;                    // the endpoint itself challenges anonymous callers
+options.ToolVisibility = McpToolVisibility.Authorized;  // advertise only what the caller may actually invoke
+```
+
+The sections below describe both knobs in detail.
+
 ### Advertising tools per caller
 
 By default every discovered tool is advertised to everyone, and a caller that invokes one it is not
@@ -428,8 +466,9 @@ All options live on `NabuMcpOptions`:
 | `FlattenBodyParameter` | `true` | Lift `[FromBody]` model properties to the top level. |
 | `ExposeHeaderParameters` | `false` | Publish `[FromHeader]` parameters as tool inputs. |
 | `ForwardedHeaders`, `ForwardedHeaderPrefixes` | credentials + tracing | Headers copied onto tool requests. |
+| `ProtectedHeaders` | credentials + proxy metadata | Headers a model-supplied argument may never override. |
 | `PropagateUser` | `true` | Seed the caller's principal onto the synthetic request. |
-| `MaxResponseBytes` | 1 MiB | Response bodies above this are truncated and flagged. |
+| `MaxResponseBytes` | 1 MiB | Cap on the buffered response body; bounds memory, larger bodies are truncated and flagged. |
 | `IncludeStructuredContent` | `true` | Emit JSON responses as MCP `structuredContent`. |
 | `TreatErrorStatusAsToolError` | `true` | Map HTTP >= 400 to `isError: true`. |
 | `MaxSchemaDepth` | `8` | Nesting limit for generated schemas. |
@@ -509,10 +548,10 @@ layers.
 
 ## Target frameworks
 
-The library multi-targets `netstandard2.0`, `net6.0` and `net8.0`:
+The library multi-targets `netstandard2.0`, `net8.0` and `net10.0`:
 
 - **netstandard2.0** builds against the ASP.NET Core 2.x packages, so ASP.NET Core 2.1/2.2 apps can use it.
-- **net6.0** and **net8.0** bind to the shared framework, so modern apps pull in no legacy assemblies.
+- **net8.0** and **net10.0** bind to the shared framework, so modern apps pull in no legacy assemblies.
 
 Version-specific APIs are handled at runtime rather than by feature-flagging behaviour: the HTTP verb
 is read through `IActionHttpMethodProvider`, which has been stable since 1.0, and the enum
@@ -583,8 +622,8 @@ The demo tokens live for 24 hours; `docker compose up` again regenerates them.
 ## Building and testing
 
 ```bash
-dotnet build          # netstandard2.0 + net6.0 + net8.0
-dotnet test           # 200 tests
+dotnet build          # netstandard2.0 + net8.0 + net10.0
+dotnet test           # 230 tests
 ```
 
 The suite covers route template parsing, tool naming, JSON schema generation, argument binding,
@@ -622,6 +661,12 @@ The workflow can also be started manually from the Actions tab with an explicit 
 
 ## Limitations
 
+- The synthetic request reproduces the HTTP application surface, not the server transport. Standard
+  request/response semantics, connection information, request services, cancellation and identity are
+  all present, but server-level features are not: TLS and client-certificate features, HTTP/2-specific
+  server features, WebSockets, response upgrade, raw transport access and some IIS/Kestrel-specific
+  features do not exist on a replayed request. Middleware that requires them will behave as it does
+  when those features are absent.
 - Actions binding `IFormFile` or form data are skipped, with a warning; tools cannot supply files.
 - Attribute routing is what discovery is built around. Conventionally routed actions fall back to a
   `{controller}/{action}` path with the remaining arguments in the query string.

--- a/src/Nabu.Mcp.AspNetCore/Execution/CappedResponseStream.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/CappedResponseStream.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nabu.Mcp.AspNetCore.Execution
+{
+    /// <summary>
+    /// Write-only response body that keeps at most <see cref="NabuMcpOptions.MaxResponseBytes"/> bytes
+    /// in memory. Bytes past the cap are counted but discarded as they arrive, so an action that
+    /// produces hundreds of megabytes costs the process no more than the cap - the truncation limit is
+    /// a memory bound, not just an output bound - while truncation remains detectable.
+    /// </summary>
+    internal sealed class CappedResponseStream : Stream
+    {
+        private readonly MemoryStream _buffer = new MemoryStream();
+        private readonly int _capacity;
+        private long _totalWritten;
+
+        public CappedResponseStream(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            _capacity = capacity;
+        }
+
+        /// <summary>Total bytes the application wrote, including the discarded tail.</summary>
+        public long TotalBytesWritten
+        {
+            get { return _totalWritten; }
+        }
+
+        /// <summary>True when the application wrote past the cap and the tail was discarded.</summary>
+        public bool Overflowed
+        {
+            get { return _totalWritten > _capacity; }
+        }
+
+        /// <summary>Decodes the retained bytes as UTF-8 without copying the buffer.</summary>
+        public string ReadBufferedText()
+        {
+            return _buffer.Length == 0
+                ? string.Empty
+                : Encoding.UTF8.GetString(_buffer.GetBuffer(), 0, (int)_buffer.Length);
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override long Length
+        {
+            get { return _totalWritten; }
+        }
+
+        public override long Position
+        {
+            get { return _totalWritten; }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled(cancellationToken)
+                : Task.CompletedTask;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (offset < 0 || count < 0 || buffer.Length - offset < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            var keep = (int)Math.Min(count, Math.Max(0L, _capacity - _buffer.Length));
+            if (keep > 0)
+            {
+                _buffer.Write(buffer, offset, keep);
+            }
+
+            _totalWritten += count;
+        }
+
+        public override void WriteByte(byte value)
+        {
+            if (_buffer.Length < _capacity)
+            {
+                _buffer.WriteByte(value);
+            }
+
+            _totalWritten++;
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            try
+            {
+                Write(buffer, offset, count);
+                return Task.CompletedTask;
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException(exception);
+            }
+        }
+
+#if !NETSTANDARD2_0
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            var keep = (int)Math.Min(buffer.Length, Math.Max(0L, _capacity - _buffer.Length));
+            if (keep > 0)
+            {
+                _buffer.Write(buffer.Slice(0, keep));
+            }
+
+            _totalWritten += buffer.Length;
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ValueTask.FromCanceled(cancellationToken);
+            }
+
+            Write(buffer.Span);
+            return default;
+        }
+#endif
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _buffer.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpArgumentBinder.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpArgumentBinder.cs
@@ -20,6 +20,12 @@ namespace Nabu.Mcp.AspNetCore.Execution
             public JsonNode? Body { get; set; }
 
             public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            /// <summary>
+            /// Header names whose values were pinned by the tool definition rather than supplied by the
+            /// model, so <see cref="NabuMcpOptions.ProtectedHeaders"/> does not apply to them.
+            /// </summary>
+            public ISet<string> ConstantHeaders { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public static BoundRequest Bind(McpToolDescriptor tool, JsonObject? arguments, Schema.McpJsonCompatibility compatibility)
@@ -95,6 +101,17 @@ namespace Nabu.Mcp.AspNetCore.Execution
                         if (header != null)
                         {
                             result.Headers[bindingName] = header;
+
+                            // Constants take the replaceExisting path; remember them so protected-header
+                            // enforcement can tell developer-pinned values from model-supplied ones.
+                            if (replaceExisting)
+                            {
+                                result.ConstantHeaders.Add(bindingName);
+                            }
+                            else
+                            {
+                                result.ConstantHeaders.Remove(bindingName);
+                            }
                         }
 
                         break;

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
@@ -102,7 +102,7 @@ namespace Nabu.Mcp.AspNetCore.Execution
 
             using (var scope = _scopeFactory.CreateScope())
             using (var requestBody = bodyBytes == null ? Stream.Null : new MemoryStream(bodyBytes, writable: false))
-            using (var responseBody = new MemoryStream())
+            using (var responseBody = new CappedResponseStream(_options.MaxResponseBytes))
             {
                 var features = BuildFeatures(tool, originalContext, bound, bodyBytes, requestBody, responseBody, scope, cancellationToken);
 
@@ -170,6 +170,18 @@ namespace Nabu.Mcp.AspNetCore.Execution
 
             foreach (var header in bound.Headers)
             {
+                // A model-supplied argument may never override credentials or proxy metadata; the value
+                // forwarded from the MCP caller stays in place. Developer-pinned constants are exempt.
+                if (_options.ProtectedHeaders.Contains(header.Key) && !bound.ConstantHeaders.Contains(header.Key))
+                {
+                    _logger.LogWarning(
+                        "Nabu MCP dropped a model-supplied value for protected header {Header} on tool {Tool}. " +
+                        "Remove the header from NabuMcpOptions.ProtectedHeaders to allow it.",
+                        header.Key,
+                        tool.Name);
+                    continue;
+                }
+
                 headers[header.Key] = header.Value;
             }
 
@@ -265,20 +277,12 @@ namespace Nabu.Mcp.AspNetCore.Execution
             return false;
         }
 
-        private McpToolInvocationResult ReadResult(HttpContext context, MemoryStream responseBody, string requestUri)
+        private McpToolInvocationResult ReadResult(HttpContext context, CappedResponseStream responseBody, string requestUri)
         {
-            var buffer = responseBody.ToArray();
-            var truncated = false;
-
-            if (buffer.Length > _options.MaxResponseBytes)
-            {
-                truncated = true;
-                var trimmed = new byte[_options.MaxResponseBytes];
-                Array.Copy(buffer, trimmed, _options.MaxResponseBytes);
-                buffer = trimmed;
-            }
-
-            var body = buffer.Length == 0 ? string.Empty : Encoding.UTF8.GetString(buffer);
+            // The stream discarded everything past MaxResponseBytes as it was written, so a huge
+            // response never occupied more memory than the cap.
+            var truncated = responseBody.Overflowed;
+            var body = responseBody.ReadBufferedText();
 
             var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var header in context.Response.Headers)

--- a/src/Nabu.Mcp.AspNetCore/NabuMcpOptions.cs
+++ b/src/Nabu.Mcp.AspNetCore/NabuMcpOptions.cs
@@ -159,6 +159,25 @@ namespace Nabu.Mcp.AspNetCore
         public bool ExposeHeaderParameters { get; set; }
 
         /// <summary>
+        /// Headers a model-supplied argument may never set on the synthetic request, even when
+        /// <see cref="ExposeHeaderParameters"/> is on. Credentials and proxy metadata forwarded from
+        /// the MCP caller keep their original values; a tool argument targeting one of these headers is
+        /// dropped with a warning. Constants pinned by the developer through
+        /// <see cref="McpToolAttribute.ConstantParameters"/> are not affected - they are developer
+        /// input, not model input. Remove a name to explicitly allow the model to supply it.
+        /// Matching is case insensitive.
+        /// </summary>
+        public ISet<string> ProtectedHeaders { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Authorization",
+            "Cookie",
+            "Host",
+            "X-Forwarded-For",
+            "X-Forwarded-Proto",
+            "X-Forwarded-Host",
+        };
+
+        /// <summary>
         /// Seeds the synthetic request with the <see cref="System.Security.Claims.ClaimsPrincipal"/> that
         /// was authenticated for the MCP request. Authentication middleware still runs and overwrites it
         /// when the forwarded credentials authenticate successfully; this only makes identity survive
@@ -168,8 +187,10 @@ namespace Nabu.Mcp.AspNetCore
         public bool PropagateUser { get; set; } = true;
 
         /// <summary>
-        /// Largest action response body, in bytes, turned into tool content. Larger responses are
-        /// truncated and flagged. Defaults to 1 MiB.
+        /// Largest action response body, in bytes, turned into tool content. This bounds memory as well
+        /// as output: the response is buffered into a capped stream that discards everything past the
+        /// limit as it is written, so an action that produces a huge response never occupies more than
+        /// this much response memory, and the result is flagged as truncated. Defaults to 1 MiB.
         /// </summary>
         public int MaxResponseBytes { get; set; } = 1024 * 1024;
 

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/StandaloneAppTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/StandaloneAppTests.cs
@@ -39,6 +39,25 @@ namespace Nabu.Mcp.AspNetCore.Tests.Integration
         [HttpGet("hidden")]
         [McpIgnore]
         public IActionResult Hidden() => Ok(new { hidden = true });
+
+        /// <summary>Produces a response body of the requested size.</summary>
+        [HttpGet("big")]
+        public IActionResult Big([FromQuery] int bytes) => Content(new string('x', bytes), "text/plain");
+
+        /// <summary>Reports the Authorization header the action received.</summary>
+        [HttpGet("auth-echo")]
+        public IActionResult AuthEcho([FromHeader(Name = "Authorization")] string? authorization) => Ok(new { authorization });
+    }
+
+    /// <summary>Controller used only by the protected-header constant tests.</summary>
+    [ApiController]
+    [Route("pinned")]
+    public class PinnedHeaderController : ControllerBase
+    {
+        /// <summary>Reports the Authorization header the action received.</summary>
+        [HttpGet("auth")]
+        [McpTool("pinned_auth", ConstantParameters = new[] { "authorization=Bearer pinned" })]
+        public IActionResult Auth([FromHeader(Name = "Authorization")] string? authorization) => Ok(new { authorization });
     }
 
     public class StandaloneAppTests
@@ -50,6 +69,11 @@ namespace Nabu.Mcp.AspNetCore.Tests.Integration
         /// </summary>
         private static IHost CreateServer(Action<NabuMcpOptions> configure)
         {
+            return CreateServer(configure, typeof(ProbeController));
+        }
+
+        private static IHost CreateServer(Action<NabuMcpOptions> configure, params Type[] controllers)
+        {
             var host = new HostBuilder()
                 .ConfigureWebHost(webHost => webHost
                     .UseTestServer()
@@ -58,7 +82,7 @@ namespace Nabu.Mcp.AspNetCore.Tests.Integration
                         services
                             .AddControllers()
                             .AddApplicationPart(typeof(ProbeController).Assembly)
-                            .OnlyControllers(typeof(ProbeController));
+                            .OnlyControllers(controllers);
 
                         services.AddNabuMcp(configure);
                     })
@@ -252,6 +276,120 @@ namespace Nabu.Mcp.AspNetCore.Tests.Integration
 
             var text = result["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
             Assert.Equal("acme", JsonNode.Parse(text)!["tenant"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task A_model_supplied_authorization_header_is_dropped_by_default()
+        {
+            using var server = CreateServer(options =>
+            {
+                options.ExposeAllActions = true;
+                options.ExposeHeaderParameters = true;
+            });
+
+            var result = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject
+                {
+                    ["name"] = "probe_auth_echo",
+                    ["arguments"] = new JsonObject { ["authorization"] = "Bearer forged-by-the-model" },
+                });
+
+            var text = result["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+
+            // The argument never reached the action; the (absent) caller credential stayed in place.
+            Assert.Null(JsonNode.Parse(text)!["authorization"]?.GetValue<string?>());
+        }
+
+        [Fact]
+        public async Task Removing_a_header_from_ProtectedHeaders_is_the_explicit_opt_in()
+        {
+            using var server = CreateServer(options =>
+            {
+                options.ExposeAllActions = true;
+                options.ExposeHeaderParameters = true;
+                options.ProtectedHeaders.Remove("Authorization");
+            });
+
+            var result = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject
+                {
+                    ["name"] = "probe_auth_echo",
+                    ["arguments"] = new JsonObject { ["authorization"] = "Bearer allowed" },
+                });
+
+            var text = result["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+            Assert.Equal("Bearer allowed", JsonNode.Parse(text)!["authorization"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task A_developer_pinned_constant_may_set_a_protected_header()
+        {
+            using var server = CreateServer(
+                options => options.ExposeHeaderParameters = true,
+                typeof(PinnedHeaderController));
+
+            var result = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject { ["name"] = "pinned_auth", ["arguments"] = new JsonObject() });
+
+            var text = result["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+
+            // The constant comes from the tool definition, not the model, so ProtectedHeaders lets it through.
+            Assert.Equal("Bearer pinned", JsonNode.Parse(text)!["authorization"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task Responses_beyond_MaxResponseBytes_are_truncated_and_flagged()
+        {
+            using var server = CreateServer(options =>
+            {
+                options.ExposeAllActions = true;
+                options.MaxResponseBytes = 64;
+            });
+
+            var result = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject
+                {
+                    ["name"] = "probe_big",
+                    ["arguments"] = new JsonObject { ["bytes"] = 500_000 },
+                });
+
+            var text = result["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+
+            Assert.StartsWith(new string('x', 64), text);
+            Assert.Contains("[truncated", text);
+            Assert.True(text.Length < 200, "The tool result must carry the capped body, not the full response.");
+        }
+
+        [Fact]
+        public async Task Responses_within_MaxResponseBytes_are_not_flagged_as_truncated()
+        {
+            using var server = CreateServer(options =>
+            {
+                options.ExposeAllActions = true;
+                options.MaxResponseBytes = 64;
+            });
+
+            var result = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject
+                {
+                    ["name"] = "probe_big",
+                    ["arguments"] = new JsonObject { ["bytes"] = 10 },
+                });
+
+            var text = result["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+
+            Assert.Equal(new string('x', 10), text);
+            Assert.DoesNotContain("[truncated", text);
         }
 
         [Fact]

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Unit/CappedResponseStreamTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Unit/CappedResponseStreamTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Nabu.Mcp.AspNetCore.Execution;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Unit
+{
+    public class CappedResponseStreamTests
+    {
+        [Fact]
+        public void A_body_under_the_cap_is_kept_verbatim()
+        {
+            using var stream = new CappedResponseStream(64);
+
+            var payload = Encoding.UTF8.GetBytes("hello world");
+            stream.Write(payload, 0, payload.Length);
+
+            Assert.False(stream.Overflowed);
+            Assert.Equal(payload.Length, stream.TotalBytesWritten);
+            Assert.Equal("hello world", stream.ReadBufferedText());
+        }
+
+        [Fact]
+        public void A_single_write_past_the_cap_keeps_only_the_cap_and_flags_overflow()
+        {
+            using var stream = new CappedResponseStream(8);
+
+            var payload = Encoding.UTF8.GetBytes(new string('x', 1000));
+            stream.Write(payload, 0, payload.Length);
+
+            Assert.True(stream.Overflowed);
+            Assert.Equal(1000, stream.TotalBytesWritten);
+            Assert.Equal(new string('x', 8), stream.ReadBufferedText());
+        }
+
+        [Fact]
+        public void Many_small_writes_crossing_the_cap_are_cut_at_the_boundary()
+        {
+            using var stream = new CappedResponseStream(10);
+
+            for (var i = 0; i < 25; i++)
+            {
+                var chunk = Encoding.UTF8.GetBytes(((char)('a' + (i % 26))).ToString());
+                stream.Write(chunk, 0, chunk.Length);
+            }
+
+            Assert.True(stream.Overflowed);
+            Assert.Equal(25, stream.TotalBytesWritten);
+            Assert.Equal("abcdefghij", stream.ReadBufferedText());
+        }
+
+        [Fact]
+        public void WriteByte_respects_the_cap()
+        {
+            using var stream = new CappedResponseStream(3);
+
+            for (var i = 0; i < 5; i++)
+            {
+                stream.WriteByte((byte)('0' + i));
+            }
+
+            Assert.True(stream.Overflowed);
+            Assert.Equal(5, stream.TotalBytesWritten);
+            Assert.Equal("012", stream.ReadBufferedText());
+        }
+
+        [Fact]
+        public async Task Async_and_span_writes_behave_like_synchronous_ones()
+        {
+            using var stream = new CappedResponseStream(6);
+
+            await stream.WriteAsync(Encoding.UTF8.GetBytes("abc"), 0, 3);
+            stream.Write(Encoding.UTF8.GetBytes("def").AsSpan());
+            await stream.WriteAsync(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("ghi")));
+
+            Assert.True(stream.Overflowed);
+            Assert.Equal(9, stream.TotalBytesWritten);
+            Assert.Equal("abcdef", stream.ReadBufferedText());
+        }
+
+        [Fact]
+        public void An_empty_body_reads_as_an_empty_string()
+        {
+            using var stream = new CappedResponseStream(16);
+
+            Assert.False(stream.Overflowed);
+            Assert.Equal(0, stream.TotalBytesWritten);
+            Assert.Equal(string.Empty, stream.ReadBufferedText());
+        }
+
+        [Fact]
+        public void The_stream_is_write_only()
+        {
+            using var stream = new CappedResponseStream(16);
+
+            Assert.True(stream.CanWrite);
+            Assert.False(stream.CanRead);
+            Assert.False(stream.CanSeek);
+            Assert.Throws<NotSupportedException>(() => stream.Read(new byte[1], 0, 1));
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, System.IO.SeekOrigin.Begin));
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds two security and resource management features to the MCP tool invocation pipeline:

1. **Response body capping with memory efficiency**: Responses are now buffered into a `CappedResponseStream` that discards bytes past the configured limit as they arrive, preventing large responses from consuming unbounded memory while still detecting truncation.

2. **Protected header enforcement**: Model-supplied arguments can no longer override sensitive headers (Authorization, Cookie, Host, X-Forwarded-* etc.), protecting against credential injection attacks. Developer-pinned constants via `ConstantParameters` remain exempt.

## Key Changes

- **New `CappedResponseStream` class**: A write-only stream that keeps at most `MaxResponseBytes` in memory. Bytes beyond the cap are counted but discarded as they arrive, so a 500MB response costs no more memory than the cap while truncation remains detectable. Supports both sync and async writes, including `ReadOnlySpan<byte>` on .NET Core.

- **Protected headers configuration**: Added `NabuMcpOptions.ProtectedHeaders` (case-insensitive set) containing Authorization, Cookie, Host, and X-Forwarded-* headers by default. Model-supplied arguments targeting these headers are dropped with a warning; developers can explicitly opt-in by removing headers from the set.

- **Header binding tracking**: `McpArgumentBinder.BoundRequest` now tracks which headers came from developer-pinned constants via a new `ConstantHeaders` set, allowing the invoker to distinguish developer input from model input.

- **Invoker integration**: `McpToolInvoker` now uses `CappedResponseStream` instead of `MemoryStream` and enforces protected headers before applying bound values, logging warnings when model-supplied protected headers are dropped.

- **Comprehensive test coverage**: Added unit tests for `CappedResponseStream` behavior (capping, overflow detection, async writes) and integration tests for protected header enforcement and response truncation scenarios.

- **Documentation updates**: README clarified the design goal of preserving HTTP application semantics, documented the new protected headers feature and recommended production configuration patterns.

## Implementation Details

The `CappedResponseStream` uses a simple but effective approach: it maintains a `MemoryStream` buffer up to capacity and tracks total bytes written separately. When a write would exceed capacity, only the portion that fits is buffered; the overflow is counted but discarded. This avoids the allocation and copying overhead of buffering the entire response before truncating.

Protected header enforcement happens in `BuildFeatures()` after argument binding but before applying headers to the request, with special handling to allow developer-pinned constants through while blocking model-supplied values.

https://claude.ai/code/session_015L1r9xfTJrpTa4bjdj5s9o