### PR TITLE
Add Minimal API support to Nabu MCP tool discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 One attribute. Same endpoint. Same authorization. Same validation. Same middleware.
 
-`Nabu.Mcp.AspNetCore` turns existing controller actions into [Model Context Protocol](https://modelcontextprotocol.io)
-tools. It does not ask you to re-declare your endpoints, duplicate validation, or re-implement your
+`Nabu.Mcp.AspNetCore` turns existing controller actions and Minimal API route handlers into
+[Model Context Protocol](https://modelcontextprotocol.io) tools. It does not ask you to re-declare your endpoints, duplicate validation, or re-implement your
 security model. A tool call is replayed as a real HTTP request through **your application's own
 pipeline**, so authentication, authorization policies, action filters, model binding, model validation,
 exception handlers and every other piece of middleware keep working exactly as they do today. Tool
@@ -23,6 +23,11 @@ shows each caller only the tools it is actually allowed to invoke - see
 public ActionResult<TodoItem> GetById(Guid id) => ...
 ```
 
+```csharp
+app.MapGet("/customers/{id}", (int id) => ...)
+   .McpTool();                              // <- same thing for Minimal APIs
+```
+
 ---
 
 ## Contents
@@ -30,6 +35,7 @@ public ActionResult<TodoItem> GetById(Guid id) => ...
 - [Why replay the pipeline](#why-replay-the-pipeline)
 - [Getting started](#getting-started)
 - [Attributes](#attributes)
+- [Minimal APIs](#minimal-apis)
 - [One action, several tools](#one-action-several-tools)
 - [How arguments are mapped](#how-arguments-are-mapped)
 - [Schema generation](#schema-generation)
@@ -163,6 +169,9 @@ curl -X POST http://localhost:5000/mcp \
 | `[McpIgnore]` | controller, action, parameter, property | Excludes it. Always wins. |
 | `[McpParameter]` | parameter, property | Overrides the name, description, requiredness or example of one input. |
 
+For Minimal APIs the same declarations are made with the `.McpTool()` / `.McpIgnore()` endpoint
+conventions (or the same attributes on the handler delegate) - see [Minimal APIs](#minimal-apis).
+
 `[McpTool]` also accepts `Name`, `Title`, `Description`, `Enabled`, and the four MCP behaviour hints
 `ReadOnly`, `Destructive`, `Idempotent` and `OpenWorld`. The hints default to the HTTP semantics of the
 verb - GET is read-only and idempotent, DELETE and PUT are destructive - and any hint you set
@@ -177,6 +186,62 @@ explicitly overrides that default.
     Destructive = true)]
 public IActionResult Publish(Guid id) => ...
 ```
+
+## Minimal APIs
+
+Route handlers publish the same way controller actions do, through an endpoint convention instead of
+an attribute:
+
+```csharp
+app.MapGet("/customers/{id}", (int id, ICustomerService customers) => customers.Get(id))
+   .McpTool();
+
+app.MapPost("/orders", (CreateOrder order) => ...)
+   .McpTool("orders_create", "Places a new order.");
+```
+
+Everything works exactly as it does for controllers, because the machinery is the same: a tool call
+is replayed as a synthetic HTTP request through the whole pipeline, so `RequireAuthorization()`,
+`[Authorize]`, endpoint filters, rate limiting and validation all keep running, and
+`ToolVisibility` reads the endpoint's own authorization metadata when tailoring `tools/list` to the
+caller. An application without any controllers at all - `AddNabuMcp()` plus `UseNabuMcp()` on a
+plain `WebApplication` - is fully supported.
+
+Inputs are inferred with Minimal API binding rules, not MVC's:
+
+| Handler parameter | Becomes |
+|---|---|
+| Route token match, `[FromRoute]` | A URL segment. |
+| `string`, primitives, parsables, and collections of them; `[FromQuery]` | A query-string entry. |
+| Complex types (and collections of them), `[FromBody]` | The JSON request body, [flattened](#how-arguments-are-mapped) like `[FromBody]`. |
+| `[FromHeader]` | A request header (opt in with `ExposeHeaderParameters`). |
+| Services (per `IServiceProviderIsService`), `[FromServices]`, `[FromKeyedServices]` | Skipped - resolved by the framework. |
+| `HttpContext`, `CancellationToken`, `ClaimsPrincipal`, `Stream`, `PipeReader`, `BindAsync` types | Skipped - materialized from the request itself. |
+
+One real difference between the stacks is preserved rather than papered over: Minimal APIs answer
+400 when a non-nullable parameter without a default value is missing, so such a parameter is
+`required` in the tool schema - where MVC model binding would have silently used the type's default.
+
+The other `[McpTool]` surfaces work here too:
+
+- `.McpTool(tool => { ... })` exposes the full attribute surface - `IncludeParameters`,
+  `ConstantParameters`, behaviour hints - and calling `.McpTool(...)` repeatedly publishes
+  [several tools over one endpoint](#one-action-several-tools).
+- An attribute on the handler itself is equivalent to the extension:
+  `app.MapGet("/ping", [McpTool("ping")] () => ...)`.
+- `.McpIgnore()` (or `[McpIgnore]` on the handler) keeps an endpoint out of discovery, which
+  matters when `ExposeAllActions` is on - that option publishes every delegate route handler just
+  as it publishes every controller action, and `ExcludeFromDescription()` is respected the way
+  `[ApiExplorerSettings(IgnoreApi = true)]` is for controllers.
+
+Without an explicit name, tools are named from the endpoint name (`.WithName(...)`), the handler's
+method name when it is a real method rather than a lambda, or the verb and route -
+`GET /customers/{id}` becomes `customers_get_by_id`. `NabuMcpOptions.ToolNameFactory` sees these
+through the same `McpToolNamingContext` it sees controllers through.
+
+Current limitations: `[AsParameters]` models and form/`IFormFile` binding are not supported - such
+endpoints are skipped with a warning. Minimal API discovery needs endpoint routing, so it exists on
+the modern targets only, not on the netstandard2.0 asset for ASP.NET Core 2.x.
 
 ## One action, several tools
 
@@ -457,7 +522,7 @@ All options live on `NabuMcpOptions`:
 | `Path` | `/mcp` | Endpoint path. |
 | `ServerName`, `ServerVersion`, `Instructions` | entry assembly | Reported during `initialize` / `server/discover`. |
 | `CacheTtlMilliseconds` | `60000` | `ttlMs` freshness hint on cacheable `2026-07-28` results. |
-| `ExposeAllActions` | `false` | Publish every action, not just annotated ones. `[McpIgnore]` still wins. |
+| `ExposeAllActions` | `false` | Publish every action and route handler, not just annotated ones. `[McpIgnore]` still wins. |
 | `RequireAuthorization`, `AuthorizationPolicy`, `AuthenticationSchemes` | off | Protects the MCP endpoint. |
 | `ToolVisibility` | `All` | Advertise every tool, or only the ones the caller is authenticated / authorized for. |
 | `AnonymousAccess` | `None` | How much of a protected endpoint an unauthorized caller may reach. |
@@ -576,9 +641,10 @@ XML documentation. Two accounts exist, both with the password `password`: `alice
 It is wired up for per-caller tool visibility, so the ordinary authorization attributes are visible at
 work. Connect without a token and `tools/list` returns the `weather_*` tools, because
 `WeatherController` carries `[AllowAnonymous]`, plus `todos_get_priorities`, because that one action
-carries `[AllowAnonymous]` even though its controller carries `[Authorize]` - and all of them can be
-called. The rest of the `todos_*` tools are neither advertised nor callable until you sign in, and
-`todos_delete` appears only for `root`, because it carries `[Authorize(Policy = "AdminOnly")]`.
+carries `[AllowAnonymous]` even though its controller carries `[Authorize]`, plus `server_time_now`,
+a Minimal API endpoint published with `.McpTool()` - and all of them can be called. The rest of the
+`todos_*` tools are neither advertised nor callable until you sign in, and `todos_delete` appears
+only for `root`, because it carries `[Authorize(Policy = "AdminOnly")]`.
 
 ```bash
 dotnet run --project samples/Nabu.Sample.TodoApi
@@ -599,7 +665,7 @@ docker compose up --build
 A one-shot init container signs in as `alice` and `root` on both samples and writes an Inspector
 config with three connections per sample, each to the same endpoint. For the Todo sample -
 `todo-anonymous`, `todo-alice-user` and `todo-root-admin` - switching between them in the UI shows
-the tool list grow from the 4 anonymous tools to alice's 10 to root's 11 (only root gets
+the tool list grow from the 5 anonymous tools to alice's 11 to root's 12 (only root gets
 `todos_delete`). For the book catalog served through the official SDK - `books-anonymous`,
 `books-alice-user` and `books-root-admin` - the list grows from the 2 search tools to alice's 3
 (`books_add`) to root's 4 (`books_remove`). The Todo API is published on
@@ -623,7 +689,7 @@ The demo tokens live for 24 hours; `docker compose up` again regenerates them.
 
 ```bash
 dotnet build          # netstandard2.0 + net8.0 + net10.0
-dotnet test           # 230 tests
+dotnet test           # 243 tests
 ```
 
 The suite covers route template parsing, tool naming, JSON schema generation, argument binding,
@@ -668,6 +734,7 @@ The workflow can also be started manually from the Actions tab with an explicit 
   features do not exist on a replayed request. Middleware that requires them will behave as it does
   when those features are absent.
 - Actions binding `IFormFile` or form data are skipped, with a warning; tools cannot supply files.
+  For Minimal APIs, `[AsParameters]` models are skipped the same way.
 - Attribute routing is what discovery is built around. Conventionally routed actions fall back to a
   `{controller}/{action}` path with the remaining arguments in the query string.
 - The server is stateless: no server-initiated notifications, no `listChanged`, no resumable streams.

--- a/samples/Nabu.Sample.TodoApi/Program.cs
+++ b/samples/Nabu.Sample.TodoApi/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -75,6 +76,14 @@ app.UseAuthorization();
 app.UseNabuMcp();
 
 app.MapControllers();
+
+// ---------------------------------------------------------------------------
+// Minimal APIs publish the same way - no controller involved. The route handler
+// is discovered from its endpoint metadata, and a tool call is replayed through
+// the same pipeline as everything else.
+// ---------------------------------------------------------------------------
+app.MapGet("/api/time", () => new { utcNow = DateTimeOffset.UtcNow })
+   .McpTool("server_time_now", "Reports the server's current UTC time.");
 
 app.Run();
 

--- a/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpEndpointConventionBuilderExtensions.cs
+++ b/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,104 @@
+#if !NETSTANDARD2_0
+using System;
+using Microsoft.AspNetCore.Builder;
+
+namespace Nabu.Mcp.AspNetCore
+{
+    /// <summary>
+    /// Publishes Minimal API route handlers as MCP tools:
+    /// <c>app.MapGet("/customers/{id}", ...).McpTool()</c>.
+    /// </summary>
+    /// <remarks>
+    /// The endpoint keeps behaving like a normal route handler. As with controller actions, Nabu never
+    /// calls the handler directly; a tool call is replayed as a synthetic HTTP request through the
+    /// application pipeline, so authentication, authorization (<c>RequireAuthorization()</c>,
+    /// <c>[Authorize]</c>), endpoint filters and validation all still run.
+    /// </remarks>
+    public static class NabuMcpEndpointConventionBuilderExtensions
+    {
+        /// <summary>Publishes the endpoint as an MCP tool with a generated name.</summary>
+        public static TBuilder McpTool<TBuilder>(this TBuilder builder)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            return builder.McpTool(new McpToolAttribute());
+        }
+
+        /// <summary>Publishes the endpoint as an MCP tool.</summary>
+        /// <param name="builder">The endpoint convention builder.</param>
+        /// <param name="name">Tool name advertised to MCP clients.</param>
+        /// <param name="description">Description shown to the model.</param>
+        public static TBuilder McpTool<TBuilder>(this TBuilder builder, string name, string? description = null)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("The tool name must not be empty.", nameof(name));
+            }
+
+            return builder.McpTool(new McpToolAttribute(name) { Description = description });
+        }
+
+        /// <summary>
+        /// Publishes the endpoint as an MCP tool configured through a delegate, giving access to the
+        /// full <see cref="McpToolAttribute"/> surface - parameter sets, constants, behaviour hints.
+        /// May be called several times to publish one endpoint as several tools.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// app.MapGet("/todos", (bool? isCompleted, int page) => ...)
+        ///    .McpTool(tool =>
+        ///    {
+        ///        tool.Name = "todos_list_open";
+        ///        tool.ConstantParameters = new[] { "isCompleted=false" };
+        ///    });
+        /// </code>
+        /// </example>
+        public static TBuilder McpTool<TBuilder>(this TBuilder builder, Action<McpToolAttribute> configure)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var tool = new McpToolAttribute();
+            configure(tool);
+            return builder.McpTool(tool);
+        }
+
+        /// <summary>Publishes the endpoint as an MCP tool described by <paramref name="tool"/>.</summary>
+        public static TBuilder McpTool<TBuilder>(this TBuilder builder, McpToolAttribute tool)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (tool == null)
+            {
+                throw new ArgumentNullException(nameof(tool));
+            }
+
+            builder.Add(endpoint => endpoint.Metadata.Add(tool));
+            return builder;
+        }
+
+        /// <summary>
+        /// Keeps the endpoint out of MCP discovery. Relevant with
+        /// <see cref="NabuMcpOptions.ExposeAllActions"/>, which otherwise publishes every route handler.
+        /// </summary>
+        public static TBuilder McpIgnore<TBuilder>(this TBuilder builder)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Add(endpoint => endpoint.Metadata.Add(new McpIgnoreAttribute()));
+            return builder;
+        }
+    }
+}
+#endif

--- a/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpServiceCollectionExtensions.cs
+++ b/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpServiceCollectionExtensions.cs
@@ -73,12 +73,25 @@ namespace Nabu.Mcp.AspNetCore
                 return new JsonSchemaGenerator(sp.GetRequiredService<IXmlDocumentationProvider>(), options.MaxSchemaDepth);
             });
 
+#if NETSTANDARD2_0
             services.TryAddSingleton<IMcpToolRegistry>(sp => new McpToolRegistry(
                 sp.GetRequiredService<Microsoft.AspNetCore.Mvc.Infrastructure.IActionDescriptorCollectionProvider>(),
                 sp.GetRequiredService<IOptions<NabuMcpOptions>>(),
                 sp.GetRequiredService<JsonSchemaGenerator>(),
                 sp.GetRequiredService<IXmlDocumentationProvider>(),
                 sp.GetService<ILogger<McpToolRegistry>>()));
+#else
+            // Both discovery sources are optional: an app without controllers still exposes its
+            // Minimal API endpoints, and vice versa.
+            services.TryAddSingleton<IMcpToolRegistry>(sp => new McpToolRegistry(
+                sp.GetService<Microsoft.AspNetCore.Mvc.Infrastructure.IActionDescriptorCollectionProvider>(),
+                sp.GetRequiredService<IOptions<NabuMcpOptions>>(),
+                sp.GetRequiredService<JsonSchemaGenerator>(),
+                sp.GetRequiredService<IXmlDocumentationProvider>(),
+                sp.GetService<Microsoft.AspNetCore.Routing.EndpointDataSource>(),
+                sp.GetService<IServiceProviderIsService>(),
+                sp.GetService<ILogger<McpToolRegistry>>()));
+#endif
 
             services.TryAddSingleton(sp => McpJsonCompatibility.Detect(
                 sp,

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
@@ -114,7 +114,10 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         public bool OpenWorld { get; set; }
     }
 
-    /// <summary>Everything Nabu needs to advertise and invoke one controller action as an MCP tool.</summary>
+    /// <summary>
+    /// Everything Nabu needs to advertise and invoke one HTTP endpoint - a controller action or a
+    /// Minimal API route handler - as an MCP tool.
+    /// </summary>
     public sealed class McpToolDescriptor
     {
         public McpToolDescriptor(
@@ -125,11 +128,22 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             IReadOnlyList<McpToolParameterDescriptor> parameters,
             JsonObject inputSchema,
             McpToolAnnotations annotations)
+            : this(name, httpMethod, routeTemplate, parameters, inputSchema, annotations)
+        {
+            Action = action;
+        }
+
+        public McpToolDescriptor(
+            string name,
+            string httpMethod,
+            string routeTemplate,
+            IReadOnlyList<McpToolParameterDescriptor> parameters,
+            JsonObject inputSchema,
+            McpToolAnnotations annotations)
         {
             Name = name;
             HttpMethod = httpMethod;
             RouteTemplate = routeTemplate;
-            Action = action;
             Parameters = parameters;
             InputSchema = inputSchema;
             Annotations = annotations;
@@ -146,7 +160,19 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         /// <summary>Route template with binding constraints stripped, for example <c>api/todos/{id}</c>.</summary>
         public string RouteTemplate { get; }
 
-        public ControllerActionDescriptor Action { get; }
+        /// <summary>
+        /// The MVC action behind the tool, or <c>null</c> when the tool was discovered from a Minimal
+        /// API endpoint - see <c>Endpoint</c> in that case.
+        /// </summary>
+        public ControllerActionDescriptor? Action { get; }
+
+#if !NETSTANDARD2_0
+        /// <summary>
+        /// The route endpoint behind the tool when it was discovered from a Minimal API route handler,
+        /// or <c>null</c> for controller-backed tools - see <see cref="Action"/> in that case.
+        /// </summary>
+        public Microsoft.AspNetCore.Http.Endpoint? Endpoint { get; set; }
+#endif
 
         /// <summary>Inputs the caller supplies. Excludes anything pinned through <see cref="Constants"/>.</summary>
         public IReadOnlyList<McpToolParameterDescriptor> Parameters { get; }

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.Endpoints.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.Endpoints.cs
@@ -1,0 +1,518 @@
+#if !NETSTANDARD2_0
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Nabu.Mcp.AspNetCore.Schema;
+
+namespace Nabu.Mcp.AspNetCore.Discovery
+{
+    /// <summary>
+    /// The Minimal API half of the registry: discovers tools from route-handler endpoints
+    /// (<c>app.MapGet(...).McpTool()</c>). Not available on the netstandard2.0 target, which builds
+    /// against ASP.NET Core 2.x - endpoint routing does not exist there.
+    /// </summary>
+    public partial class McpToolRegistry
+    {
+        private readonly EndpointDataSource? _endpointDataSource;
+        private readonly IServiceProviderIsService? _serviceProviderIsService;
+
+        /// <summary>Bumped whenever the endpoint data source reports a change, to invalidate the cache.</summary>
+        private int _endpointVersion;
+
+        /// <remarks>
+        /// <paramref name="actionProvider"/> may be <c>null</c> in an application that hosts no
+        /// controllers, and <paramref name="endpointDataSource"/> may be <c>null</c> to skip Minimal
+        /// API discovery. <paramref name="serviceProviderIsService"/> is used the same way Minimal
+        /// APIs use it: a handler parameter resolvable from the container is bound from services, not
+        /// from the request, so it is not a tool input.
+        /// </remarks>
+        public McpToolRegistry(
+            IActionDescriptorCollectionProvider? actionProvider,
+            IOptions<NabuMcpOptions> options,
+            JsonSchemaGenerator schemaGenerator,
+            IXmlDocumentationProvider documentation,
+            EndpointDataSource? endpointDataSource,
+            IServiceProviderIsService? serviceProviderIsService,
+            ILogger<McpToolRegistry>? logger)
+            : this(actionProvider, options, schemaGenerator, documentation, logger)
+        {
+            _endpointDataSource = endpointDataSource;
+            _serviceProviderIsService = serviceProviderIsService;
+
+            if (endpointDataSource != null)
+            {
+                // Endpoints mapped after the first tools/list (or conditionally at startup) must not be
+                // served from a stale cache; the registry is a singleton, so the subscription lives for
+                // the application's lifetime.
+                ChangeToken.OnChange(endpointDataSource.GetChangeToken, () => Interlocked.Increment(ref _endpointVersion));
+            }
+        }
+
+        private void BuildEndpointTools(List<McpToolDescriptor> results, ISet<string> usedNames)
+        {
+            var source = _endpointDataSource;
+            if (source == null)
+            {
+                return;
+            }
+
+            foreach (var endpoint in source.Endpoints)
+            {
+                if (!(endpoint is RouteEndpoint routeEndpoint))
+                {
+                    continue;
+                }
+
+                List<McpToolDescriptor> tools;
+                try
+                {
+                    tools = CreateEndpointTools(routeEndpoint, usedNames);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Nabu MCP could not expose the endpoint {Endpoint} as a tool.",
+                        routeEndpoint.DisplayName ?? routeEndpoint.RoutePattern.RawText);
+                    continue;
+                }
+
+                foreach (var tool in tools)
+                {
+                    if (_options.ToolFilter != null && !_options.ToolFilter(tool))
+                    {
+                        continue;
+                    }
+
+                    results.Add(tool);
+                }
+            }
+        }
+
+        private List<McpToolDescriptor> CreateEndpointTools(RouteEndpoint endpoint, ISet<string> usedNames)
+        {
+            var empty = new List<McpToolDescriptor>();
+            var metadata = endpoint.Metadata;
+
+            // Controller actions and Razor pages carry an ActionDescriptor and are covered by the MVC
+            // discovery path; listing them here would duplicate every tool.
+            if (metadata.GetMetadata<Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor>() != null)
+            {
+                return empty;
+            }
+
+            if (metadata.GetMetadata<McpIgnoreAttribute>() != null)
+            {
+                return empty;
+            }
+
+            // Route handlers publish their handler's MethodInfo into the endpoint metadata, and an
+            // attribute applied to the handler lambda lands there too - so both `.McpTool()` and
+            // `app.MapGet("/x", [McpTool] (int id) => ...)` are found by the same lookup.
+            var method = metadata.GetMetadata<MethodInfo>();
+            var variants = new List<McpToolAttribute?>(metadata.GetOrderedMetadata<McpToolAttribute>());
+
+            if (variants.Count == 0)
+            {
+                // Blanket exposure covers delegate route handlers only - other endpoint kinds (hubs,
+                // health checks, ...) have no parameter surface to describe - and respects the API
+                // description opt-out, mirroring what ExposeAllActions does for controllers.
+                if (!_options.ExposeAllActions || method == null)
+                {
+                    return empty;
+                }
+
+                if (metadata.GetMetadata<IExcludeFromDescriptionMetadata>()?.ExcludeFromDescription == true)
+                {
+                    return empty;
+                }
+
+                variants.Add(null);
+            }
+
+            var routeTemplate = endpoint.RoutePattern.RawText;
+            if (string.IsNullOrEmpty(routeTemplate))
+            {
+                _logger.LogWarning(
+                    "Nabu MCP skipped the endpoint {Endpoint}: its route pattern has no textual template.",
+                    endpoint.DisplayName);
+                return empty;
+            }
+
+            routeTemplate = RouteTemplateHelper.Normalize(routeTemplate!);
+
+            if (method == null)
+            {
+                _logger.LogWarning(
+                    "Nabu MCP skipped the endpoint {Endpoint}: it carries [McpTool] metadata but no handler " +
+                    "MethodInfo, so its inputs cannot be inferred. Only delegate route handlers are supported.",
+                    endpoint.DisplayName ?? routeTemplate);
+                return empty;
+            }
+
+            var allParameters = new List<McpToolParameterDescriptor>();
+            string httpMethod;
+            var display = BuildEndpointDisplay(endpoint, metadata, routeTemplate, out httpMethod);
+
+            if (!TryBuildEndpointParameters(method, routeTemplate, display, allParameters))
+            {
+                return empty;
+            }
+
+            // Map() without verbs: mirror the controller inference - POST when something binds from
+            // the body, GET otherwise.
+            if (httpMethod.Length == 0)
+            {
+                httpMethod = allParameters.Any(p => p.Source == McpParameterSource.Body) ? "POST" : "GET";
+                display = httpMethod + " /" + routeTemplate;
+            }
+
+            if (variants.Count > 1 && variants.Count(v => string.IsNullOrEmpty(v?.Name)) > 1)
+            {
+                _logger.LogWarning(
+                    "Nabu MCP found {Count} [McpTool] occurrences on {Endpoint} without an explicit Name. " +
+                    "Give each variant a name, otherwise all but the first are published under a generated '_2', '_3', ... suffix.",
+                    variants.Count,
+                    display);
+            }
+
+            var authorization = ResolveEndpointAuthorization(metadata);
+            var namingContext = BuildEndpointNamingContext(metadata, method, httpMethod, routeTemplate);
+            var fallbackTitle = httpMethod + " /" + routeTemplate;
+            var results = new List<McpToolDescriptor>(variants.Count);
+
+            foreach (var attribute in variants)
+            {
+                if (attribute != null && !attribute.Enabled)
+                {
+                    continue;
+                }
+
+                List<McpToolParameterDescriptor> parameters;
+                List<McpToolConstantDescriptor> constants;
+                if (!TryApplyVariant(display, attribute, routeTemplate, allParameters, out parameters, out constants))
+                {
+                    continue;
+                }
+
+                var name = string.IsNullOrEmpty(attribute?.Name)
+                    ? ReserveName(_options.ToolNameFactory(namingContext), usedNames, display)
+                    : ReserveName(attribute!.Name!, usedNames, display);
+
+                var inputSchema = BuildInputSchema(parameters);
+                var annotations = BuildAnnotations(attribute, attribute, httpMethod, fallbackTitle);
+
+                results.Add(new McpToolDescriptor(name, httpMethod, routeTemplate, parameters, inputSchema, annotations)
+                {
+                    Description = ResolveEndpointDescription(attribute, method, httpMethod, routeTemplate),
+                    Constants = constants,
+                    Authorization = authorization,
+                    Endpoint = endpoint,
+                });
+            }
+
+            return results;
+        }
+
+        private static string BuildEndpointDisplay(
+            RouteEndpoint endpoint,
+            EndpointMetadataCollection metadata,
+            string routeTemplate,
+            out string httpMethod)
+        {
+            httpMethod = string.Empty;
+
+            var methods = metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods;
+            if (methods != null && methods.Count > 0)
+            {
+                // Prefer a verb that is unambiguous for a tool call, as the controller path does.
+                foreach (var preferred in new[] { "POST", "PUT", "PATCH", "DELETE", "GET" })
+                {
+                    if (methods.Any(m => string.Equals(m, preferred, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        httpMethod = preferred;
+                        break;
+                    }
+                }
+
+                if (httpMethod.Length == 0)
+                {
+                    httpMethod = methods[0].ToUpperInvariant();
+                }
+            }
+
+            return httpMethod.Length > 0 ? httpMethod + " /" + routeTemplate : "/" + routeTemplate;
+        }
+
+        /// <summary>
+        /// Reads the authorization metadata endpoint routing would enforce for this endpoint:
+        /// <c>[Authorize]</c> data added by attributes or <c>RequireAuthorization()</c>, policy
+        /// instances contributed directly, and <c>[AllowAnonymous]</c>, which wins outright.
+        /// </summary>
+        private static McpToolAuthorization ResolveEndpointAuthorization(EndpointMetadataCollection metadata)
+        {
+            var allowAnonymous = metadata.GetMetadata<IAllowAnonymous>() != null;
+            var authorizeData = new List<IAuthorizeData>(metadata.GetOrderedMetadata<IAuthorizeData>());
+            var policies = new List<AuthorizationPolicy>(metadata.GetOrderedMetadata<AuthorizationPolicy>());
+            return new McpToolAuthorization(allowAnonymous, authorizeData, policies);
+        }
+
+        /// <summary>
+        /// A route handler has no controller/action pair, so the naming context is synthesized: the
+        /// endpoint name (<c>.WithName(...)</c>) or the handler method's own name when it has a real
+        /// one, otherwise the verb plus the route tokens - so <c>GET /customers/{id}</c> becomes
+        /// <c>customers_get_by_id</c> under the default factory.
+        /// </summary>
+        private static McpToolNamingContext BuildEndpointNamingContext(
+            EndpointMetadataCollection metadata,
+            MethodInfo method,
+            string httpMethod,
+            string routeTemplate)
+        {
+            var endpointName = metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName;
+            if (!string.IsNullOrEmpty(endpointName))
+            {
+                return new McpToolNamingContext(string.Empty, endpointName!, httpMethod, routeTemplate);
+            }
+
+            var literals = new List<string>();
+            foreach (var segment in routeTemplate.Split('/'))
+            {
+                if (segment.Length > 0 && segment.IndexOf('{') < 0)
+                {
+                    literals.Add(segment);
+                }
+            }
+
+            var controllerName = string.Join("_", literals);
+
+            // A method-group handler has a meaningful name; a lambda's compiler-generated one does not.
+            if (method.Name.IndexOf('<') < 0 && !method.Name.StartsWith("lambda_method", StringComparison.Ordinal))
+            {
+                return new McpToolNamingContext(controllerName, method.Name, httpMethod, routeTemplate);
+            }
+
+            var tokens = RouteTemplateHelper.GetTokenNames(routeTemplate);
+            var actionName = httpMethod.ToLowerInvariant();
+            if (tokens.Count > 0)
+            {
+                actionName += "_by_" + string.Join("_", tokens);
+            }
+
+            return new McpToolNamingContext(controllerName, actionName, httpMethod, routeTemplate);
+        }
+
+        private string? ResolveEndpointDescription(
+            McpToolAttribute? attribute,
+            MethodInfo method,
+            string httpMethod,
+            string routeTemplate)
+        {
+            if (!string.IsNullOrEmpty(attribute?.Description))
+            {
+                return attribute!.Description;
+            }
+
+            // Method-group handlers can carry XML documentation; lambdas cannot.
+            var summary = _documentation.GetSummary(method);
+            if (!string.IsNullOrEmpty(summary))
+            {
+                var returns = _documentation.GetReturnsDescription(method);
+                return string.IsNullOrEmpty(returns) ? summary : summary + " Returns: " + returns;
+            }
+
+            return "Invokes " + httpMethod + " /" + routeTemplate + ".";
+        }
+
+        private bool TryBuildEndpointParameters(
+            MethodInfo method,
+            string routeTemplate,
+            string display,
+            List<McpToolParameterDescriptor> parameters)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var parameterInfo in method.GetParameters())
+            {
+                var type = parameterInfo.ParameterType;
+                var attributes = parameterInfo.GetCustomAttributes().ToList();
+
+                if (attributes.Any(a => a is McpIgnoreAttribute))
+                {
+                    continue;
+                }
+
+                if (IsIgnoredType(type) || typeof(System.IO.Pipelines.PipeReader).IsAssignableFrom(type))
+                {
+                    continue;
+                }
+
+                if (attributes.Any(a => a is IFromServiceMetadata || a is FromKeyedServicesAttribute))
+                {
+                    continue;
+                }
+
+                if (IsFormType(type) || attributes.Any(a => a is IFromFormMetadata))
+                {
+                    _logger.LogWarning(
+                        "Nabu MCP skipped {Endpoint}: parameter '{Parameter}' binds form data, which tools cannot supply.",
+                        display,
+                        parameterInfo.Name);
+                    return false;
+                }
+
+                if (attributes.Any(a => a is AsParametersAttribute))
+                {
+                    _logger.LogWarning(
+                        "Nabu MCP skipped {Endpoint}: [AsParameters] on '{Parameter}' is not supported yet. " +
+                        "Bind the values as individual handler parameters to expose this endpoint as a tool.",
+                        display,
+                        parameterInfo.Name);
+                    return false;
+                }
+
+                var bindingName = parameterInfo.Name ?? string.Empty;
+                McpParameterSource source;
+
+                var fromRoute = attributes.OfType<IFromRouteMetadata>().FirstOrDefault();
+                var fromQuery = attributes.OfType<IFromQueryMetadata>().FirstOrDefault();
+                var fromHeader = attributes.OfType<IFromHeaderMetadata>().FirstOrDefault();
+                var fromBody = attributes.OfType<IFromBodyMetadata>().FirstOrDefault();
+
+                if (fromRoute != null)
+                {
+                    source = McpParameterSource.Route;
+                    bindingName = fromRoute.Name ?? bindingName;
+                }
+                else if (fromQuery != null)
+                {
+                    source = McpParameterSource.Query;
+                    bindingName = fromQuery.Name ?? bindingName;
+                }
+                else if (fromHeader != null)
+                {
+                    if (!_options.ExposeHeaderParameters)
+                    {
+                        continue;
+                    }
+
+                    source = McpParameterSource.Header;
+                    bindingName = fromHeader.Name ?? bindingName;
+                }
+                else if (fromBody != null)
+                {
+                    source = McpParameterSource.Body;
+                }
+                else if (RouteTemplateHelper.ContainsToken(routeTemplate, bindingName))
+                {
+                    source = McpParameterSource.Route;
+                }
+                else if (!JsonSchemaGenerator.IsComplexObject(type) &&
+                         !HasComplexElementType(type))
+                {
+                    // Strings, primitives, parsables and their collections bind from the query string.
+                    source = McpParameterSource.Query;
+                }
+                else if (_serviceProviderIsService != null && _serviceProviderIsService.IsService(type))
+                {
+                    // Minimal APIs bind a parameter the container can resolve from services, so it is
+                    // not part of the endpoint's request surface.
+                    continue;
+                }
+                else if (HasBindAsync(type))
+                {
+                    // The framework materializes these from the HttpContext itself; a tool cannot and
+                    // need not supply them.
+                    continue;
+                }
+                else if (HasTryParse(type))
+                {
+                    source = McpParameterSource.Query;
+                }
+                else
+                {
+                    // Unlike MVC, Minimal APIs infer the body for complex types on every verb.
+                    source = McpParameterSource.Body;
+                }
+
+                AddParameter(
+                    method,
+                    parameterInfo.Name ?? bindingName,
+                    bindingName,
+                    type,
+                    parameterInfo,
+                    source,
+                    routeTemplate,
+                    parameters,
+                    seen,
+                    valueTypesDefaultToOptional: false);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// True for collections whose elements are complex objects - those bind from the JSON body in
+        /// Minimal APIs, while collections of simple values bind from repeated query keys.
+        /// </summary>
+        private static bool HasComplexElementType(Type type)
+        {
+            var element = JsonSchemaGenerator.GetEnumerableElementType(type);
+            return element != null && JsonSchemaGenerator.IsComplexObject(element);
+        }
+
+        private static bool HasBindAsync(Type type)
+        {
+            foreach (var candidate in type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
+            {
+                if (!string.Equals(candidate.Name, "BindAsync", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var parameters = candidate.GetParameters();
+                if (parameters.Length >= 1 && parameters.Length <= 2 &&
+                    parameters[0].ParameterType == typeof(HttpContext))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasTryParse(Type type)
+        {
+            var underlying = Nullable.GetUnderlyingType(type) ?? type;
+            foreach (var candidate in underlying.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
+            {
+                if (!string.Equals(candidate.Name, "TryParse", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var parameters = candidate.GetParameters();
+                if (parameters.Length >= 2 &&
+                    parameters[0].ParameterType == typeof(string) &&
+                    parameters[parameters.Length - 1].IsOut)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
@@ -24,10 +24,11 @@ using Nabu.Mcp.AspNetCore.Schema;
 namespace Nabu.Mcp.AspNetCore.Discovery
 {
     /// <summary>
-    /// Discovers MCP tools from the MVC action table. The result is cached and rebuilt automatically
-    /// whenever the action descriptor collection changes (for example when application parts are added).
+    /// Discovers MCP tools from the MVC action table and - on modern frameworks - from Minimal API
+    /// route handlers. The result is cached and rebuilt automatically whenever the action descriptor
+    /// collection or the endpoint data source changes (for example when application parts are added).
     /// </summary>
-    public class McpToolRegistry : IMcpToolRegistry
+    public partial class McpToolRegistry : IMcpToolRegistry
     {
         private static readonly Type[] IgnoredParameterTypes =
         {
@@ -46,25 +47,29 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             "Microsoft.AspNetCore.Http.IFormCollection",
         };
 
-        private readonly IActionDescriptorCollectionProvider _actionProvider;
+        private readonly IActionDescriptorCollectionProvider? _actionProvider;
         private readonly NabuMcpOptions _options;
         private readonly JsonSchemaGenerator _schemaGenerator;
         private readonly IXmlDocumentationProvider _documentation;
         private readonly ILogger _logger;
 
         private readonly object _sync = new object();
-        private int _cachedVersion = -1;
+        private long _cachedVersion = -1;
         private IReadOnlyList<McpToolDescriptor>? _tools;
         private IReadOnlyDictionary<string, McpToolDescriptor>? _byName;
 
+        /// <remarks>
+        /// <paramref name="actionProvider"/> may be <c>null</c> in an application that hosts no
+        /// controllers, in which case only Minimal API endpoints are discovered.
+        /// </remarks>
         public McpToolRegistry(
-            IActionDescriptorCollectionProvider actionProvider,
+            IActionDescriptorCollectionProvider? actionProvider,
             IOptions<NabuMcpOptions> options,
             JsonSchemaGenerator schemaGenerator,
             IXmlDocumentationProvider documentation,
             ILogger<McpToolRegistry>? logger = null)
         {
-            _actionProvider = actionProvider ?? throw new ArgumentNullException(nameof(actionProvider));
+            _actionProvider = actionProvider;
             _options = (options ?? throw new ArgumentNullException(nameof(options))).Value;
             _schemaGenerator = schemaGenerator ?? throw new ArgumentNullException(nameof(schemaGenerator));
             _documentation = documentation ?? NullXmlDocumentationProvider.Instance;
@@ -89,23 +94,40 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             return _byName!.TryGetValue(name, out tool) && tool != null;
         }
 
+        /// <summary>
+        /// A single number that changes whenever either discovery source changes: the MVC action table
+        /// version in the upper half, the endpoint change counter in the lower half.
+        /// </summary>
+        private long CurrentVersion()
+        {
+            long version = _actionProvider != null ? _actionProvider.ActionDescriptors.Version : 0;
+            version <<= 32;
+#if !NETSTANDARD2_0
+            version |= (uint)Volatile.Read(ref _endpointVersion);
+#endif
+            return version;
+        }
+
         private void EnsureBuilt()
         {
-            var collection = _actionProvider.ActionDescriptors;
-            if (_tools != null && _cachedVersion == collection.Version)
+            if (_tools != null && _cachedVersion == CurrentVersion())
             {
                 return;
             }
 
             lock (_sync)
             {
-                collection = _actionProvider.ActionDescriptors;
-                if (_tools != null && _cachedVersion == collection.Version)
+                var version = CurrentVersion();
+                if (_tools != null && _cachedVersion == version)
                 {
                     return;
                 }
 
-                var tools = Build(collection.Items);
+                var actions = _actionProvider?.ActionDescriptors.Items
+                              ?? (IReadOnlyList<Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor>)
+                                  new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor[0];
+
+                var tools = Build(actions);
                 var byName = new Dictionary<string, McpToolDescriptor>(StringComparer.Ordinal);
                 foreach (var tool in tools)
                 {
@@ -114,7 +136,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
 
                 _tools = tools;
                 _byName = byName;
-                _cachedVersion = collection.Version;
+                _cachedVersion = version;
 
                 _logger.LogInformation("Nabu MCP discovered {ToolCount} tool(s).", tools.Count);
             }
@@ -157,6 +179,10 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     results.Add(tool);
                 }
             }
+
+#if !NETSTANDARD2_0
+            BuildEndpointTools(results, used);
+#endif
 
             results.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
             return results;
@@ -216,6 +242,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     action.ActionName);
             }
 
+            var display = action.ControllerName + "." + action.ActionName;
             var httpMethod = ResolveHttpMethod(action);
             var routeTemplate = ResolveRouteTemplate(action);
             if (routeTemplate == null)
@@ -244,14 +271,14 @@ namespace Nabu.Mcp.AspNetCore.Discovery
 
                 List<McpToolParameterDescriptor> parameters;
                 List<McpToolConstantDescriptor> constants;
-                if (!TryApplyVariant(action, attribute, routeTemplate, allParameters, out parameters, out constants))
+                if (!TryApplyVariant(display, attribute, routeTemplate, allParameters, out parameters, out constants))
                 {
                     continue;
                 }
 
                 var methodAttribute = isMethodLevel ? attribute : null;
                 var inputSchema = BuildInputSchema(parameters);
-                var annotations = BuildAnnotations(attribute, methodAttribute, httpMethod, action);
+                var annotations = BuildAnnotations(attribute, methodAttribute, httpMethod, Humanize(action.ActionName));
                 var name = ResolveName(action, methodAttribute, httpMethod, routeTemplate, usedNames);
 
                 results.Add(new McpToolDescriptor(name, httpMethod, routeTemplate, action, parameters, inputSchema, annotations)
@@ -340,7 +367,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         /// Returns <c>false</c> when the variant cannot produce a callable tool.
         /// </summary>
         private bool TryApplyVariant(
-            ControllerActionDescriptor action,
+            string display,
             McpToolAttribute? attribute,
             string routeTemplate,
             IReadOnlyList<McpToolParameterDescriptor> allParameters,
@@ -360,9 +387,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             var exclude = BuildNameSet(attribute.ExcludeParameters);
             var required = BuildNameSet(attribute.RequiredParameters);
             var optional = BuildNameSet(attribute.OptionalParameters);
-            var pinned = BuildConstantMap(attribute, action);
+            var pinned = BuildConstantMap(attribute, display);
 
-            WarnAboutUnknownNames(action, allParameters, include, exclude, required, optional, pinned?.Keys);
+            WarnAboutUnknownNames(display, allParameters, include, exclude, required, optional, pinned?.Keys);
 
             foreach (var parameter in allParameters)
             {
@@ -378,10 +405,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     if (value == null && isRequiredRouteToken)
                     {
                         _logger.LogWarning(
-                            "Nabu MCP skipped a [McpTool] variant on {Controller}.{Action}: route parameter '{Parameter}' " +
+                            "Nabu MCP skipped a [McpTool] variant on {Endpoint}: route parameter '{Parameter}' " +
                             "was pinned to an empty value but '{Template}' cannot be built without it.",
-                            action.ControllerName,
-                            action.ActionName,
+                            display,
                             parameter.Name,
                             routeTemplate);
                         return false;
@@ -408,10 +434,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     if (isRequiredRouteToken)
                     {
                         _logger.LogWarning(
-                            "Nabu MCP skipped a [McpTool] variant on {Controller}.{Action}: route parameter '{Parameter}' " +
+                            "Nabu MCP skipped a [McpTool] variant on {Endpoint}: route parameter '{Parameter}' " +
                             "was hidden but '{Template}' cannot be built without it. Pin it with ConstantParameters instead.",
-                            action.ControllerName,
-                            action.ActionName,
+                            display,
                             parameter.Name,
                             routeTemplate);
                         return false;
@@ -470,7 +495,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             return set.Count == 0 ? null : set;
         }
 
-        private IDictionary<string, string>? BuildConstantMap(McpToolAttribute attribute, ControllerActionDescriptor action)
+        private IDictionary<string, string>? BuildConstantMap(McpToolAttribute attribute, string display)
         {
             var entries = attribute.ConstantParameters;
             if (entries == null || entries.Length == 0)
@@ -486,10 +511,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 if (!McpConstantValue.TrySplit(entry, out name, out value))
                 {
                     _logger.LogWarning(
-                        "Nabu MCP ignored the ConstantParameters entry '{Entry}' on {Controller}.{Action}: expected 'name=value'.",
+                        "Nabu MCP ignored the ConstantParameters entry '{Entry}' on {Endpoint}: expected 'name=value'.",
                         entry,
-                        action.ControllerName,
-                        action.ActionName);
+                        display);
                     continue;
                 }
 
@@ -524,7 +548,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         /// the full parameter set - so every configured name that matches nothing is reported.
         /// </summary>
         private void WarnAboutUnknownNames(
-            ControllerActionDescriptor action,
+            string display,
             IReadOnlyList<McpToolParameterDescriptor> allParameters,
             params IEnumerable<string>?[] configuredNames)
         {
@@ -547,10 +571,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     if (!known.Contains(name))
                     {
                         _logger.LogWarning(
-                            "Nabu MCP ignored '{Name}' in an [McpTool] variant on {Controller}.{Action}: the action has no such input.",
+                            "Nabu MCP ignored '{Name}' in an [McpTool] variant on {Endpoint}: the endpoint has no such input.",
                             name,
-                            action.ControllerName,
-                            action.ActionName);
+                            display);
                     }
                 }
             }
@@ -570,7 +593,16 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 name = _options.ToolNameFactory(context);
             }
 
-            name = Sanitize(name!);
+            return ReserveName(name!, usedNames, action.ControllerName + "." + action.ActionName);
+        }
+
+        /// <summary>
+        /// Sanitizes a tool name and claims it in <paramref name="usedNames"/>, appending a numeric
+        /// suffix when overloads map to the same generated name.
+        /// </summary>
+        private string ReserveName(string name, ISet<string> usedNames, string display)
+        {
+            name = Sanitize(name);
             if (name.Length == 0)
             {
                 name = "tool";
@@ -581,7 +613,6 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 return name;
             }
 
-            // Overloaded actions map to the same generated name; disambiguate deterministically.
             var suffix = 2;
             string candidate;
             do
@@ -592,10 +623,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             while (!usedNames.Add(candidate));
 
             _logger.LogWarning(
-                "Nabu MCP tool name '{Name}' was already taken; {Controller}.{Action} is exposed as '{Candidate}'.",
+                "Nabu MCP tool name '{Name}' was already taken; {Endpoint} is exposed as '{Candidate}'.",
                 name,
-                action.ControllerName,
-                action.ActionName,
+                display,
                 candidate);
 
             return candidate;
@@ -650,12 +680,12 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             McpToolAttribute? attribute,
             McpToolAttribute? methodAttribute,
             string httpMethod,
-            ControllerActionDescriptor action)
+            string fallbackTitle)
         {
             var isRead = httpMethod == "GET" || httpMethod == "HEAD" || httpMethod == "OPTIONS";
             var annotations = new McpToolAnnotations
             {
-                Title = methodAttribute?.Title ?? attribute?.Title ?? Humanize(action.ActionName),
+                Title = methodAttribute?.Title ?? attribute?.Title ?? fallbackTitle,
                 ReadOnly = isRead,
                 Destructive = httpMethod == "DELETE" || httpMethod == "PUT",
                 Idempotent = isRead || httpMethod == "PUT" || httpMethod == "DELETE",
@@ -845,7 +875,17 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 }
 
                 var resolved = ResolveSource(source, parameter, parameterInfo, httpMethod, routeTemplate);
-                AddParameter(action, parameter, parameterInfo, resolved, routeTemplate, parameters, seen);
+                var bindingName = parameter.BindingInfo?.BinderModelName ?? parameter.Name;
+                AddParameter(
+                    action.MethodInfo,
+                    parameter.Name,
+                    bindingName,
+                    parameter.ParameterType,
+                    parameterInfo,
+                    resolved,
+                    routeTemplate,
+                    parameters,
+                    seen);
             }
 
             return true;
@@ -897,21 +937,24 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         }
 
         private void AddParameter(
-            ControllerActionDescriptor action,
-            Microsoft.AspNetCore.Mvc.Abstractions.ParameterDescriptor parameter,
+            MethodBase? documentationMethod,
+            string parameterName,
+            string bindingName,
+            Type type,
             ParameterInfo? parameterInfo,
             McpParameterSource source,
             string routeTemplate,
             List<McpToolParameterDescriptor> parameters,
-            ISet<string> seen)
+            ISet<string> seen,
+            bool valueTypesDefaultToOptional = true)
         {
-            var bindingName = parameter.BindingInfo?.BinderModelName ?? parameter.Name;
             var attributes = parameterInfo?.GetCustomAttributes().ToList() ?? new List<Attribute>();
             var mcpAttribute = parameterInfo?.GetCustomAttribute<McpParameterAttribute>();
-            var type = parameter.ParameterType;
 
             var description = JsonSchemaGenerator.ReadDescription(attributes)
-                              ?? _documentation.GetParameterDescription(action.MethodInfo, parameter.Name);
+                              ?? (documentationMethod != null
+                                  ? _documentation.GetParameterDescription(documentationMethod, parameterName)
+                                  : null);
 
             var isComplex = JsonSchemaGenerator.IsComplexObject(type);
             var shouldFlatten = isComplex &&
@@ -946,7 +989,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             // documents. A header name such as "X-Tenant" makes a poor tool argument, so header
             // parameters are advertised under their CLR parameter name instead.
             var schemaName = mcpAttribute?.Name ?? JsonNamingPolicy.CamelCase.ConvertName(
-                source == McpParameterSource.Header ? parameter.Name : bindingName);
+                source == McpParameterSource.Header ? parameterName : bindingName);
             schemaName = Deduplicate(schemaName, seen);
 
             var nullable = parameterInfo != null ? NullabilityHelper.IsNullable(parameterInfo) : null;
@@ -957,7 +1000,8 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 schema["description"] = description;
             }
 
-            var isRequired = ResolveRequired(parameter, parameterInfo, attributes, mcpAttribute, source, routeTemplate, bindingName, nullable);
+            var isRequired = ResolveRequired(
+                type, parameterInfo, attributes, mcpAttribute, source, routeTemplate, bindingName, nullable, valueTypesDefaultToOptional);
 
             parameters.Add(new McpToolParameterDescriptor(schemaName, bindingName, source, type, isRequired, schema)
             {
@@ -985,15 +1029,22 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             return candidate;
         }
 
+        /// <remarks>
+        /// <paramref name="valueTypesDefaultToOptional"/> encodes a real difference between the two
+        /// binding stacks: MVC model binding gives a missing non-nullable value type its default value,
+        /// while Minimal APIs answer 400 - so the same <c>int page</c> parameter is optional on a
+        /// controller and required on a route handler.
+        /// </remarks>
         private static bool ResolveRequired(
-            Microsoft.AspNetCore.Mvc.Abstractions.ParameterDescriptor parameter,
+            Type parameterType,
             ParameterInfo? parameterInfo,
             IList<Attribute> attributes,
             McpParameterAttribute? mcpAttribute,
             McpParameterSource source,
             string routeTemplate,
             string bindingName,
-            bool? nullable)
+            bool? nullable,
+            bool valueTypesDefaultToOptional)
         {
             if (mcpAttribute?.RequiredOverride != null)
             {
@@ -1020,10 +1071,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 return nullable != true;
             }
 
-            var type = parameter.ParameterType;
-            if (type.IsValueType && Nullable.GetUnderlyingType(type) == null)
+            if (parameterType.IsValueType && Nullable.GetUnderlyingType(parameterType) == null)
             {
-                return false;
+                return !valueTypesDefaultToOptional;
             }
 
             return nullable == false;

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
@@ -212,6 +212,10 @@ namespace Nabu.Mcp.AspNetCore.Execution
             features.Set<IHttpResponseFeature>(responseFeature);
 #if !NETSTANDARD2_0
             features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(responseBody));
+
+            // Minimal API body binding asks this feature whether a body exists at all before reading
+            // the stream, and treats an absent feature as "no body". MVC never consults it.
+            features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(bodyBytes != null && bodyBytes.Length > 0));
 #endif
 
             features.Set<IHttpRequestLifetimeFeature>(new HttpRequestLifetimeFeature
@@ -276,6 +280,18 @@ namespace Nabu.Mcp.AspNetCore.Execution
 
             return false;
         }
+
+#if !NETSTANDARD2_0
+        private sealed class RequestBodyDetectionFeature : IHttpRequestBodyDetectionFeature
+        {
+            public RequestBodyDetectionFeature(bool canHaveBody)
+            {
+                CanHaveBody = canHaveBody;
+            }
+
+            public bool CanHaveBody { get; }
+        }
+#endif
 
         private McpToolInvocationResult ReadResult(HttpContext context, CappedResponseStream responseBody, string requestUri)
         {

--- a/src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
+++ b/src/Nabu.Mcp.AspNetCore/Nabu.Mcp.AspNetCore.csproj
@@ -15,8 +15,9 @@
     <Title>Nabu.NET - MCP tools for ASP.NET Core Web APIs</Title>
     <Description>
       Expose existing ASP.NET Core Web API actions as Model Context Protocol (MCP) tools by adding a
-      single [McpTool] attribute. Tool calls are replayed through the application's own HTTP pipeline,
-      so authentication, authorization, filters, model binding and validation all keep working.
+      single [McpTool] attribute - or Minimal API endpoints with .McpTool(). Tool calls are replayed
+      through the application's own HTTP pipeline, so authentication, authorization, filters, model
+      binding and validation all keep working.
     </Description>
     <PackageTags>mcp;model-context-protocol;aspnetcore;webapi;ai;llm;tools</PackageTags>
   </PropertyGroup>

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/MinimalApiTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/MinimalApiTests.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Nabu.Mcp.AspNetCore;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// Minimal API endpoints published with <c>.McpTool()</c> (or a <c>[McpTool]</c> attribute on the
+    /// handler), in an application that registers no controllers at all.
+    /// </summary>
+    public class MinimalApiTests
+    {
+        /// <summary>A service the container can resolve, so handler parameters of this type bind from DI.</summary>
+        public sealed class Multiplier
+        {
+            public int Apply(int value) => value * 2;
+        }
+
+        public sealed class CreateOrder
+        {
+            public string Title { get; set; } = string.Empty;
+
+            public int Quantity { get; set; }
+        }
+
+        private static IHost CreateServer(
+            Action<IEndpointRouteBuilder> map,
+            Action<NabuMcpOptions>? configure = null,
+            Action<IServiceCollection>? services = null)
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(collection =>
+                    {
+                        collection.AddRouting();
+                        collection.AddNabuMcp(configure ?? (_ => { }));
+                        services?.Invoke(collection);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp();
+                        app.UseEndpoints(endpoints => map(endpoints));
+                    }))
+                .Build();
+
+            host.Start();
+            return host;
+        }
+
+        private static async Task<JsonObject> RpcAsync(IHost server, string method, JsonObject? parameters = null)
+        {
+            var request = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = method,
+            };
+
+            if (parameters != null)
+            {
+                request["params"] = parameters;
+            }
+
+            using var client = server.GetTestClient();
+            using var response = await client.PostAsync(
+                "/mcp",
+                new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json"));
+
+            return JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        }
+
+        private static async Task<JsonArray> ToolsAsync(IHost server)
+        {
+            var envelope = await RpcAsync(server, "tools/list");
+            return envelope["result"]!["tools"]!.AsArray();
+        }
+
+        private static async Task<string[]> ToolNamesAsync(IHost server)
+        {
+            return (await ToolsAsync(server)).Select(t => t!["name"]!.GetValue<string>()).ToArray();
+        }
+
+        private static async Task<string> CallAsync(IHost server, string name, JsonObject arguments)
+        {
+            var envelope = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject { ["name"] = name, ["arguments"] = arguments });
+
+            return envelope["result"]!["content"]!.AsArray()[0]!["text"]!.GetValue<string>();
+        }
+
+        [Fact]
+        public async Task McpTool_publishes_a_route_handler_with_a_route_derived_name()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/customers/{id:int}", (int id) => Results.Ok(new { id })).McpTool());
+
+            var tools = await ToolsAsync(server);
+            var tool = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "customers_get_by_id");
+
+            var schema = tool!["inputSchema"]!.AsObject();
+            Assert.Equal("integer", schema["properties"]!["id"]!["type"]!.GetValue<string>());
+            Assert.Contains("id", schema["required"]!.AsArray().Select(n => n!.GetValue<string>()));
+        }
+
+        [Fact]
+        public async Task Unadorned_endpoints_are_not_published()
+        {
+            using var server = CreateServer(endpoints =>
+            {
+                endpoints.MapGet("/visible", () => Results.Ok()).McpTool("visible_tool");
+                endpoints.MapGet("/invisible", () => Results.Ok());
+            });
+
+            var names = await ToolNamesAsync(server);
+
+            Assert.Contains("visible_tool", names);
+            Assert.Single(names);
+        }
+
+        [Fact]
+        public async Task An_explicit_name_and_description_are_honoured()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/customers/{id:int}", (int id) => Results.Ok(new { id }))
+                         .McpTool("get_customer", "Fetches a single customer."));
+
+            var tools = await ToolsAsync(server);
+            var tool = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "get_customer");
+
+            Assert.Equal("Fetches a single customer.", tool!["description"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task A_tool_call_replays_route_and_query_arguments_through_the_pipeline()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/greet/{name}", (string name, string? punctuation) =>
+                    Results.Ok(new { greeting = "Hello, " + name + (punctuation ?? "!") })).McpTool("greet"));
+
+            var text = await CallAsync(server, "greet", new JsonObject
+            {
+                ["name"] = "Ada",
+                ["punctuation"] = "?!",
+            });
+
+            Assert.Equal("Hello, Ada?!", JsonNode.Parse(text)!["greeting"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task A_complex_parameter_becomes_a_flattened_json_body()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapPost("/orders", (CreateOrder order) =>
+                    Results.Ok(new { order.Title, order.Quantity })).McpTool("orders_create"));
+
+            var tools = await ToolsAsync(server);
+            var tool = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "orders_create");
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+
+            // The body model's properties sit at the top level of the schema, not under "order".
+            Assert.NotNull(properties["title"]);
+            Assert.NotNull(properties["quantity"]);
+            Assert.Null(properties["order"]);
+
+            var text = await CallAsync(server, "orders_create", new JsonObject
+            {
+                ["title"] = "Widgets",
+                ["quantity"] = 3,
+            });
+
+            var body = JsonNode.Parse(text)!;
+            Assert.Equal("Widgets", body["title"]!.GetValue<string>());
+            Assert.Equal(3, body["quantity"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_parameter_resolvable_from_the_container_is_not_a_tool_input()
+        {
+            using var server = CreateServer(
+                endpoints => endpoints.MapGet("/double/{value:int}", (Multiplier multiplier, int value) =>
+                    Results.Ok(new { result = multiplier.Apply(value) })).McpTool("double"),
+                services: collection => collection.AddSingleton<Multiplier>());
+
+            var tools = await ToolsAsync(server);
+            var tool = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "double");
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+
+            Assert.Single(properties);
+            Assert.NotNull(properties["value"]);
+
+            var text = await CallAsync(server, "double", new JsonObject { ["value"] = 21 });
+            Assert.Equal(42, JsonNode.Parse(text)!["result"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task An_attribute_on_the_handler_lambda_works_like_the_extension()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/ping", [McpTool("ping_tool")] () => Results.Ok(new { pong = true })));
+
+            Assert.Contains("ping_tool", await ToolNamesAsync(server));
+        }
+
+        [Fact]
+        public async Task ExposeAllActions_publishes_route_handlers_and_McpIgnore_wins()
+        {
+            using var server = CreateServer(
+                endpoints =>
+                {
+                    endpoints.MapGet("/list", () => Results.Ok());
+                    endpoints.MapGet("/hidden", () => Results.Ok()).McpIgnore();
+                },
+                options => options.ExposeAllActions = true);
+
+            var names = await ToolNamesAsync(server);
+
+            Assert.Contains("list_get", names);
+            Assert.DoesNotContain(names, n => n.Contains("hidden"));
+        }
+
+        [Fact]
+        public async Task Controller_backed_endpoints_are_not_discovered_twice()
+        {
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(collection =>
+                    {
+                        collection
+                            .AddControllers()
+                            .AddApplicationPart(typeof(ProbeController).Assembly)
+                            .OnlyControllers(typeof(ProbeController));
+
+                        collection.AddNabuMcp(options => options.ExposeAllActions = true);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapGet("/minimal", () => Results.Ok(new { minimal = true })).McpTool("minimal_tool");
+                        });
+                    }))
+                .Build();
+
+            host.Start();
+            using var server = host;
+
+            var names = await ToolNamesAsync(server);
+
+            // Controller actions come from the MVC path only; the route handler from the endpoint path.
+            Assert.Contains("probe_echo", names);
+            Assert.Contains("minimal_tool", names);
+            Assert.Equal(names.Length, names.Distinct(StringComparer.Ordinal).Count());
+            Assert.Single(names, n => n == "probe_echo");
+        }
+
+        [Fact]
+        public async Task RequireAuthorization_hides_the_tool_from_anonymous_callers_when_visibility_is_authorized()
+        {
+            using var server = CreateServer(
+                endpoints =>
+                {
+                    endpoints.MapGet("/open", () => Results.Ok()).McpTool("open_tool");
+                    endpoints.MapGet("/secure", () => Results.Ok()).RequireAuthorization().McpTool("secure_tool");
+                },
+                options => options.ToolVisibility = McpToolVisibility.Authorized,
+                services: collection => collection.AddAuthorization());
+
+            var names = await ToolNamesAsync(server);
+
+            Assert.Contains("open_tool", names);
+            Assert.DoesNotContain("secure_tool", names);
+        }
+
+        [Fact]
+        public async Task One_endpoint_can_publish_several_tools_with_pinned_constants()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/items", (bool? all, int? page) =>
+                        Results.Ok(new { all = all ?? false, page = page ?? 0 }))
+                    .McpTool("items_list")
+                    .McpTool(tool =>
+                    {
+                        tool.Name = "items_list_all";
+                        tool.ConstantParameters = new[] { "all=true" };
+                    }));
+
+            var tools = await ToolsAsync(server);
+            var names = tools.Select(t => t!["name"]!.GetValue<string>()).ToArray();
+
+            Assert.Contains("items_list", names);
+            Assert.Contains("items_list_all", names);
+
+            var pinned = tools.Single(t => t!["name"]!.GetValue<string>() == "items_list_all");
+            Assert.Null(pinned!["inputSchema"]!["properties"]!["all"]);
+
+            var text = await CallAsync(server, "items_list_all", new JsonObject { ["page"] = 2 });
+            var body = JsonNode.Parse(text)!;
+            Assert.True(body["all"]!.GetValue<bool>());
+            Assert.Equal(2, body["page"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_non_nullable_value_type_without_a_default_is_required()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/page", (int page, int pageSize = 20) => Results.Ok(new { page, pageSize }))
+                         .McpTool("page_tool"));
+
+            var tools = await ToolsAsync(server);
+            var tool = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "page_tool");
+            var required = tool!["inputSchema"]!["required"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray();
+
+            // Minimal APIs answer 400 when `page` is missing, so the schema must demand it; `pageSize`
+            // has a default and stays optional.
+            Assert.Contains("page", required);
+            Assert.DoesNotContain("pageSize", required);
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/ToolDiscoveryTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/ToolDiscoveryTests.cs
@@ -58,6 +58,24 @@ namespace Nabu.Mcp.AspNetCore.Tests.Integration
         }
 
         [Fact]
+        public async Task A_minimal_api_endpoint_published_with_McpTool_is_discovered_and_callable()
+        {
+            var tools = await ListToolsAsync();
+            var tool = Find(tools, "server_time_now");
+
+            Assert.Equal("Reports the server's current UTC time.", tool["description"]!.GetValue<string>());
+
+            var envelope = await _fixture.RpcAsync(
+                "tools/call",
+                new JsonObject { ["name"] = "server_time_now", ["arguments"] = new JsonObject() },
+                token: await _fixture.GetTokenAsync("alice"));
+
+            var result = envelope["result"]!.AsObject();
+            Assert.False(result["isError"]?.GetValue<bool>() ?? false);
+            Assert.NotNull(result["structuredContent"]!["utcNow"]);
+        }
+
+        [Fact]
         public async Task Actions_marked_with_McpIgnore_are_not_published()
         {
             var tools = await ListToolsAsync();


### PR DESCRIPTION
## Summary

This PR extends Nabu MCP to discover and expose Minimal API route handlers as MCP tools, in addition to the existing controller action support. Route handlers can now be published using `.McpTool()` endpoint conventions or `[McpTool]` attributes on handler delegates.

## Key Changes

- **New Minimal API discovery**: Added `McpToolRegistry.Endpoints.cs` partial class that discovers tools from `EndpointDataSource` and `RouteEndpoint` metadata, mirroring the existing MVC discovery logic
- **Endpoint convention builders**: Added `NabuMcpEndpointConventionBuilderExtensions` providing fluent `.McpTool()` methods for route handlers with support for:
  - Auto-generated names from route patterns
  - Explicit names and descriptions
  - Configuration delegates for advanced scenarios (constants, parameter sets, behavior hints)
  - `.McpIgnore()` to exclude endpoints from discovery
- **Parameter binding inference**: Implemented intelligent parameter source detection for Minimal APIs:
  - Route parameters from `{tokens}` in the route template
  - Query string for simple types
  - Request body for complex types
  - Service resolution from DI container (excluded from tool inputs)
  - Support for `[FromRoute]`, `[FromQuery]`, `[FromHeader]`, `[FromBody]` binding metadata
- **Authorization integration**: Endpoint authorization metadata (`RequireAuthorization()`, `[Authorize]`, `[AllowAnonymous]`) is properly read and respected
- **Cache invalidation**: Added change token subscription to `EndpointDataSource` to invalidate the tool cache when endpoints are dynamically added
- **Dual-source versioning**: Modified `CurrentVersion()` to combine MVC action descriptor version with endpoint change counter for proper cache coherency
- **Framework compatibility**: All Minimal API code is conditional on `!NETSTANDARD2_0` since endpoint routing doesn't exist in ASP.NET Core 2.x
- **Comprehensive tests**: Added `MinimalApiTests.cs` with 11 test cases covering basic discovery, parameter binding, DI integration, authorization, and multi-tool scenarios
- **Documentation**: Updated README with Minimal API examples and usage patterns

## Implementation Details

- The endpoint discovery respects the same `ToolFilter`, `ExposeAllActions`, and `ToolVisibility` options as controller discovery
- Controller-backed endpoints are explicitly filtered out to prevent duplication when both MVC and Minimal API discovery are active
- Tool invocation uses the same synthetic HTTP request replay mechanism as controllers, ensuring all middleware, filters, and validation run normally
- Parameter flattening for complex body types works identically to the MVC path
- The registry remains a singleton with thread-safe cache updates using lock-based synchronization

https://claude.ai/code/session_01Fvpu1e1hwTD6KdDRwJGgfV