### PR TITLE
Add form binding and [AsParameters] support for Minimal APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ app.MapGet("/customers/{id}", (int id) => ...)
 - [Minimal APIs](#minimal-apis)
 - [One action, several tools](#one-action-several-tools)
 - [How arguments are mapped](#how-arguments-are-mapped)
+- [File uploads](#file-uploads)
 - [Schema generation](#schema-generation)
 - [Authentication and authorization](#authentication-and-authorization)
 - [Configuration](#configuration)
@@ -218,6 +219,10 @@ Inputs are inferred with Minimal API binding rules, not MVC's:
 | `string`, primitives, parsables, and collections of them; `[FromQuery]` | A query-string entry. |
 | Complex types (and collections of them), `[FromBody]` | The JSON request body, [flattened](#how-arguments-are-mapped) like `[FromBody]`. |
 | `[FromHeader]` | A request header (opt in with `ExposeHeaderParameters`). |
+| `IFormFile`, `IFormFileCollection`, collections of `IFormFile` | A [base64 file argument](#file-uploads), replayed as a multipart/form-data part. |
+| `[FromForm]` | A form field; complex form models are flattened like `[FromBody]`. |
+| `IFormCollection` | A free-form object whose properties become form fields. |
+| `[AsParameters]` complex models | Expanded member by member, each with these same rules. |
 | Services (per `IServiceProviderIsService`), `[FromServices]`, `[FromKeyedServices]` | Skipped - resolved by the framework. |
 | `HttpContext`, `CancellationToken`, `ClaimsPrincipal`, `Stream`, `PipeReader`, `BindAsync` types | Skipped - materialized from the request itself. |
 
@@ -242,9 +247,17 @@ method name when it is a real method rather than a lambda, or the verb and route
 `GET /customers/{id}` becomes `customers_get_by_id`. `NabuMcpOptions.ToolNameFactory` sees these
 through the same `McpToolNamingContext` it sees controllers through.
 
-Current limitations: `[AsParameters]` models and form/`IFormFile` binding are not supported - such
-endpoints are skipped with a warning. Minimal API discovery needs endpoint routing, so it exists on
-the modern targets only, not on the netstandard2.0 asset for ASP.NET Core 2.x.
+`[AsParameters]` surface types are expanded member by member - constructor parameters and settable
+properties each get the same binding inference they would as a top-level handler parameter, so a
+record gathering a route token, a query filter and a paging default publishes exactly the schema the
+individual parameters would have. Form binding - `IFormFile` included - works as it does for
+controllers; see [File uploads and form data](#file-uploads).
+
+One current limitation: Minimal API discovery needs endpoint routing, so it exists on the modern
+targets only, not on the netstandard2.0 asset for ASP.NET Core 2.x. On .NET 8+ remember that form
+endpoints demand antiforgery by default - a tool call cannot carry an antiforgery token, so such
+endpoints need `.DisableAntiforgery()` (or the app's `UseAntiforgery()` setup) exactly as any
+non-browser client does.
 
 ## One action, several tools
 
@@ -322,6 +335,8 @@ Nabu reads MVC's own binding metadata, so it maps arguments the same way your AP
 | `[FromQuery]` | A query-string entry. Arrays repeat the key; objects use `key.property`. |
 | `[FromBody]` | The JSON request body. |
 | `[FromHeader]` | A request header (opt in with `ExposeHeaderParameters`). |
+| `[FromForm]` | A form field in the request body; complex form models are flattened. |
+| `IFormFile`, `IFormFileCollection` | A [base64 file argument](#file-uploads), sent as a multipart part. |
 | `[FromServices]`, `CancellationToken`, `HttpContext` | Skipped - resolved by the framework. |
 
 When no explicit attribute is present, Nabu infers the source exactly as `[ApiController]` does: route
@@ -339,6 +354,40 @@ public ActionResult<TodoItem> Create([FromBody] CreateTodoRequest request)
 
 Set `FlattenBodyParameter = false` to keep the wrapper. Types that are not objects - a `[FromBody]
 int[]`, for example - are always sent as the whole body under their parameter name.
+
+## File uploads
+
+An action that binds `IFormFile`, a collection of files, `[FromForm]` fields or an
+`IFormCollection` is published like any other. A file becomes a tool argument carrying the content
+as base64:
+
+```jsonc
+// upload_document arguments
+{
+  "title": "Quarterly report",
+  "file": {
+    "data": "JVBERi0xLjcK...",          // required - the content, base64-encoded
+    "fileName": "report.pdf",           // optional - defaults to the parameter name
+    "contentType": "application/pdf"    // optional - defaults to application/octet-stream
+  }
+}
+```
+
+At invocation time Nabu decodes the content and rebuilds the request the way a browser would have
+sent it - `multipart/form-data` when a file is present, `application/x-www-form-urlencoded` when the
+form carries only fields - so the action's own model binding, `[Required]` validation and size
+limits (`RequestSizeLimit`, `FormOptions`) all apply unchanged. A bare base64 string is accepted as
+a shorthand for the object form. Complex `[FromForm]` models are flattened into the tool schema the
+same way `[FromBody]` models are, and a file-typed property inside one stays a file argument.
+
+Two things to know:
+
+- File content travels base64-encoded inside the JSON-RPC request, so it is subject to whatever
+  body-size limit the MCP endpoint itself is under; tools are a fit for documents and images, not
+  multi-gigabyte payloads.
+- On .NET 8+ Minimal APIs, form-binding endpoints require antiforgery by default. A tool call cannot
+  carry an antiforgery token - configure such endpoints the way you would for any non-browser
+  client, typically `.DisableAntiforgery()` on the endpoint.
 
 ## Schema generation
 
@@ -736,8 +785,9 @@ The workflow can also be started manually from the Actions tab with an explicit 
   server features, WebSockets, response upgrade, raw transport access and some IIS/Kestrel-specific
   features do not exist on a replayed request. Middleware that requires them will behave as it does
   when those features are absent.
-- Actions binding `IFormFile` or form data are skipped, with a warning; tools cannot supply files.
-  For Minimal APIs, `[AsParameters]` models are skipped the same way.
+- File content reaches a tool base64-encoded inside the JSON-RPC body, so uploads are bounded by the
+  MCP endpoint's own request-size limits - fine for documents and images, wrong for very large
+  payloads. See [File uploads](#file-uploads).
 - Attribute routing is what discovery is built around. Conventionally routed actions fall back to a
   `{controller}/{action}` path with the remaining arguments in the query string.
 - The server is stateless: no server-initiated notifications, no `listChanged`, no resumable streams.

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -183,8 +183,10 @@ app.UseNabuMcp(); // now mounts the official SDK's Streamable HTTP endpoint at t
         HTTP/2-specific server features, WebSockets, response upgrade, raw transport access and some
         IIS/Kestrel-specific features do not exist on a replayed request. Middleware that requires them
         will behave as it does when those features are absent.</li>
-      <li>Actions binding <code>IFormFile</code> or form data are skipped, with a warning; tools cannot
-        supply files. For Minimal APIs, <code>[AsParameters]</code> models are skipped the same way.</li>
+      <li>File uploads are supported: <code>IFormFile</code> and form-data actions publish file
+        arguments that carry the content base64-encoded, replayed as multipart/form-data. The content
+        travels inside the JSON-RPC body, so uploads are bounded by the MCP endpoint's request-size
+        limits — fine for documents and images, wrong for very large payloads.</li>
       <li>Attribute routing is what discovery is built around. Conventionally routed actions fall back to
         a <code>{controller}/{action}</code> path with the remaining arguments in the query string.</li>
       <li>The server is stateless: no server-initiated notifications, no <code>listChanged</code>, no

--- a/docs/minimal-apis.html
+++ b/docs/minimal-apis.html
@@ -117,11 +117,22 @@ app.MapPost("/orders", (CreateOrder order) =&gt; ...)
       <code>McpToolNamingContext</code> it sees controllers through.
     </p>
 
+    <h2 id="forms-and-asparameters">Forms and [AsParameters]</h2>
+    <p>
+      <code>[AsParameters]</code> surface types are expanded member by member — constructor parameters
+      and settable properties each get the same binding inference they would as a top-level handler
+      parameter. Form binding works too: an <code>IFormFile</code> becomes a tool argument carrying the
+      content as base64 (<code>data</code>, plus optional <code>fileName</code> and
+      <code>contentType</code>), and the invoker replays it as a real multipart/form-data request, so
+      the endpoint's own form binding, validation and size limits apply unchanged. On .NET 8+, form
+      endpoints demand antiforgery by default — a tool call cannot carry an antiforgery token, so such
+      endpoints need <code>.DisableAntiforgery()</code> exactly as any non-browser client does.
+    </p>
+
     <h2 id="limitations">Current limitations</h2>
     <div class="note">
-      <code>[AsParameters]</code> models and form/<code>IFormFile</code> binding are not supported —
-      such endpoints are skipped with a warning. Minimal API discovery needs endpoint routing, so it
-      exists on the modern targets only, not on the netstandard2.0 asset for ASP.NET Core 2.x.
+      Minimal API discovery needs endpoint routing, so it exists on the modern targets only, not on
+      the netstandard2.0 asset for ASP.NET Core 2.x.
     </div>
 
     <div class="pager">

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
@@ -19,6 +19,12 @@ namespace Nabu.Mcp.AspNetCore.Discovery
 
         /// <summary>Sent as a request header.</summary>
         Header,
+
+        /// <summary>Sent as a form field in the request body.</summary>
+        Form,
+
+        /// <summary>Sent as a file part of a multipart/form-data request body.</summary>
+        FormFile,
     }
 
     /// <summary>A single input of a tool, and how it maps back onto the action's binding sources.</summary>

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.Endpoints.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.Endpoints.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using System.Threading;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -171,10 +172,15 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             }
 
             // Map() without verbs: mirror the controller inference - POST when something binds from
-            // the body, GET otherwise.
+            // the body or the form, GET otherwise.
             if (httpMethod.Length == 0)
             {
-                httpMethod = allParameters.Any(p => p.Source == McpParameterSource.Body) ? "POST" : "GET";
+                httpMethod = allParameters.Any(p =>
+                    p.Source == McpParameterSource.Body ||
+                    p.Source == McpParameterSource.Form ||
+                    p.Source == McpParameterSource.FormFile)
+                    ? "POST"
+                    : "GET";
                 display = httpMethod + " /" + routeTemplate;
             }
 
@@ -345,7 +351,6 @@ namespace Nabu.Mcp.AspNetCore.Discovery
 
             foreach (var parameterInfo in method.GetParameters())
             {
-                var type = parameterInfo.ParameterType;
                 var attributes = parameterInfo.GetCustomAttributes().ToList();
 
                 if (attributes.Any(a => a is McpIgnoreAttribute))
@@ -353,113 +358,289 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     continue;
                 }
 
-                if (IsIgnoredType(type) || typeof(System.IO.Pipelines.PipeReader).IsAssignableFrom(type))
-                {
-                    continue;
-                }
-
-                if (attributes.Any(a => a is IFromServiceMetadata || a is FromKeyedServicesAttribute))
-                {
-                    continue;
-                }
-
-                if (IsFormType(type) || attributes.Any(a => a is IFromFormMetadata))
-                {
-                    _logger.LogWarning(
-                        "Nabu MCP skipped {Endpoint}: parameter '{Parameter}' binds form data, which tools cannot supply.",
-                        display,
-                        parameterInfo.Name);
-                    return false;
-                }
-
                 if (attributes.Any(a => a is AsParametersAttribute))
                 {
-                    _logger.LogWarning(
-                        "Nabu MCP skipped {Endpoint}: [AsParameters] on '{Parameter}' is not supported yet. " +
-                        "Bind the values as individual handler parameters to expose this endpoint as a tool.",
-                        display,
-                        parameterInfo.Name);
-                    return false;
-                }
-
-                var bindingName = parameterInfo.Name ?? string.Empty;
-                McpParameterSource source;
-
-                var fromRoute = attributes.OfType<IFromRouteMetadata>().FirstOrDefault();
-                var fromQuery = attributes.OfType<IFromQueryMetadata>().FirstOrDefault();
-                var fromHeader = attributes.OfType<IFromHeaderMetadata>().FirstOrDefault();
-                var fromBody = attributes.OfType<IFromBodyMetadata>().FirstOrDefault();
-
-                if (fromRoute != null)
-                {
-                    source = McpParameterSource.Route;
-                    bindingName = fromRoute.Name ?? bindingName;
-                }
-                else if (fromQuery != null)
-                {
-                    source = McpParameterSource.Query;
-                    bindingName = fromQuery.Name ?? bindingName;
-                }
-                else if (fromHeader != null)
-                {
-                    if (!_options.ExposeHeaderParameters)
+                    if (!TryExpandAsParameters(method, parameterInfo, routeTemplate, display, parameters, seen))
                     {
-                        continue;
+                        return false;
                     }
 
-                    source = McpParameterSource.Header;
-                    bindingName = fromHeader.Name ?? bindingName;
-                }
-                else if (fromBody != null)
-                {
-                    source = McpParameterSource.Body;
-                }
-                else if (RouteTemplateHelper.ContainsToken(routeTemplate, bindingName))
-                {
-                    source = McpParameterSource.Route;
-                }
-                else if (!JsonSchemaGenerator.IsComplexObject(type) &&
-                         !HasComplexElementType(type))
-                {
-                    // Strings, primitives, parsables and their collections bind from the query string.
-                    source = McpParameterSource.Query;
-                }
-                else if (_serviceProviderIsService != null && _serviceProviderIsService.IsService(type))
-                {
-                    // Minimal APIs bind a parameter the container can resolve from services, so it is
-                    // not part of the endpoint's request surface.
                     continue;
-                }
-                else if (HasBindAsync(type))
-                {
-                    // The framework materializes these from the HttpContext itself; a tool cannot and
-                    // need not supply them.
-                    continue;
-                }
-                else if (HasTryParse(type))
-                {
-                    source = McpParameterSource.Query;
-                }
-                else
-                {
-                    // Unlike MVC, Minimal APIs infer the body for complex types on every verb.
-                    source = McpParameterSource.Body;
                 }
 
-                AddParameter(
+                AddEndpointMember(
                     method,
-                    parameterInfo.Name ?? bindingName,
-                    bindingName,
-                    type,
-                    parameterInfo,
-                    source,
                     routeTemplate,
+                    parameterInfo.Name ?? string.Empty,
+                    parameterInfo.ParameterType,
+                    attributes,
+                    parameterInfo,
+                    propertyInfo: null,
                     parameters,
-                    seen,
-                    valueTypesDefaultToOptional: false);
+                    seen);
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Adds one bindable member - a handler parameter, or a constructor parameter / property of an
+        /// <c>[AsParameters]</c> surface type - applying Minimal API binding inference. Members the
+        /// framework materializes itself (services, <c>HttpContext</c>, <c>BindAsync</c> types, ...)
+        /// are silently skipped.
+        /// </summary>
+        private void AddEndpointMember(
+            MethodInfo method,
+            string routeTemplate,
+            string memberName,
+            Type type,
+            IList<Attribute> attributes,
+            ParameterInfo? parameterInfo,
+            PropertyInfo? propertyInfo,
+            List<McpToolParameterDescriptor> parameters,
+            ISet<string> seen)
+        {
+            if (IsIgnoredType(type) || typeof(System.IO.Pipelines.PipeReader).IsAssignableFrom(type))
+            {
+                return;
+            }
+
+            if (attributes.Any(a => a is IFromServiceMetadata || a is FromKeyedServicesAttribute))
+            {
+                return;
+            }
+
+            var bindingName = memberName;
+            McpParameterSource source;
+            JsonObject? schemaOverride = null;
+            var isFormRoot = false;
+
+            var fromRoute = attributes.OfType<IFromRouteMetadata>().FirstOrDefault();
+            var fromQuery = attributes.OfType<IFromQueryMetadata>().FirstOrDefault();
+            var fromHeader = attributes.OfType<IFromHeaderMetadata>().FirstOrDefault();
+            var fromBody = attributes.OfType<IFromBodyMetadata>().FirstOrDefault();
+            var fromForm = attributes.OfType<IFromFormMetadata>().FirstOrDefault();
+            var formKind = GetFormParameterKind(type);
+
+            if (formKind == FormParameterKind.File || formKind == FormParameterKind.FileCollection)
+            {
+                source = McpParameterSource.FormFile;
+                bindingName = fromForm?.Name ?? bindingName;
+                schemaOverride = BuildFileArgumentSchema(formKind == FormParameterKind.FileCollection);
+            }
+            else if (formKind == FormParameterKind.FormCollection)
+            {
+                source = McpParameterSource.Form;
+                schemaOverride = BuildFormCollectionSchema();
+                isFormRoot = true;
+            }
+            else if (fromForm != null)
+            {
+                source = McpParameterSource.Form;
+                bindingName = fromForm.Name ?? bindingName;
+            }
+            else if (fromRoute != null)
+            {
+                source = McpParameterSource.Route;
+                bindingName = fromRoute.Name ?? bindingName;
+            }
+            else if (fromQuery != null)
+            {
+                source = McpParameterSource.Query;
+                bindingName = fromQuery.Name ?? bindingName;
+            }
+            else if (fromHeader != null)
+            {
+                if (!_options.ExposeHeaderParameters)
+                {
+                    return;
+                }
+
+                source = McpParameterSource.Header;
+                bindingName = fromHeader.Name ?? bindingName;
+            }
+            else if (fromBody != null)
+            {
+                source = McpParameterSource.Body;
+            }
+            else if (RouteTemplateHelper.ContainsToken(routeTemplate, bindingName))
+            {
+                source = McpParameterSource.Route;
+            }
+            else if (!JsonSchemaGenerator.IsComplexObject(type) &&
+                     !HasComplexElementType(type))
+            {
+                // Strings, primitives, parsables and their collections bind from the query string.
+                source = McpParameterSource.Query;
+            }
+            else if (_serviceProviderIsService != null && _serviceProviderIsService.IsService(type))
+            {
+                // Minimal APIs bind a parameter the container can resolve from services, so it is
+                // not part of the endpoint's request surface.
+                return;
+            }
+            else if (HasBindAsync(type))
+            {
+                // The framework materializes these from the HttpContext itself; a tool cannot and
+                // need not supply them.
+                return;
+            }
+            else if (HasTryParse(type))
+            {
+                source = McpParameterSource.Query;
+            }
+            else
+            {
+                // Unlike MVC, Minimal APIs infer the body for complex types on every verb.
+                source = McpParameterSource.Body;
+            }
+
+            AddParameter(
+                method,
+                memberName,
+                bindingName,
+                type,
+                parameterInfo,
+                source,
+                routeTemplate,
+                parameters,
+                seen,
+                valueTypesDefaultToOptional: false,
+                propertyInfo: propertyInfo,
+                schemaOverride: schemaOverride,
+                isFormRoot: isFormRoot);
+        }
+
+        /// <summary>
+        /// Expands an <c>[AsParameters]</c> surface type into individual tool inputs. Each constructor
+        /// parameter and settable property is bound with the same inference it would get as a top-level
+        /// handler parameter, which is how <c>RequestDelegateFactory</c> treats them.
+        /// </summary>
+        private bool TryExpandAsParameters(
+            MethodInfo method,
+            ParameterInfo parameterInfo,
+            string routeTemplate,
+            string display,
+            List<McpToolParameterDescriptor> parameters,
+            ISet<string> seen)
+        {
+            var type = parameterInfo.ParameterType;
+            if (!JsonSchemaGenerator.IsComplexObject(type))
+            {
+                _logger.LogWarning(
+                    "Nabu MCP skipped {Endpoint}: [AsParameters] on '{Parameter}' does not target a class or struct with bindable members.",
+                    display,
+                    parameterInfo.Name);
+                return false;
+            }
+
+            foreach (var member in GetAsParametersMembers(type))
+            {
+                if (member.Attributes.Any(a => a is McpIgnoreAttribute))
+                {
+                    continue;
+                }
+
+                if (member.Attributes.Any(a => a is AsParametersAttribute))
+                {
+                    _logger.LogWarning(
+                        "Nabu MCP skipped {Endpoint}: nested [AsParameters] on '{Member}' is not supported.",
+                        display,
+                        member.Name);
+                    return false;
+                }
+
+                AddEndpointMember(
+                    method,
+                    routeTemplate,
+                    member.Name,
+                    member.Type,
+                    member.Attributes,
+                    member.Parameter,
+                    member.Property,
+                    parameters,
+                    seen);
+            }
+
+            return true;
+        }
+
+        private readonly struct AsParametersMember
+        {
+            public AsParametersMember(string name, Type type, IList<Attribute> attributes, ParameterInfo? parameter, PropertyInfo? property)
+            {
+                Name = name;
+                Type = type;
+                Attributes = attributes;
+                Parameter = parameter;
+                Property = property;
+            }
+
+            public string Name { get; }
+
+            public Type Type { get; }
+
+            public IList<Attribute> Attributes { get; }
+
+            public ParameterInfo? Parameter { get; }
+
+            public PropertyInfo? Property { get; }
+        }
+
+        /// <summary>
+        /// The bindable surface of an <c>[AsParameters]</c> type: the parameters of its single public
+        /// parameterized constructor (records), merged with attributes from matching properties, plus
+        /// any settable properties the constructor does not cover (mutable classes and structs).
+        /// </summary>
+        private static IEnumerable<AsParametersMember> GetAsParametersMembers(Type type)
+        {
+            var properties = type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.GetIndexParameters().Length == 0)
+                .ToList();
+
+            var covered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var constructors = type.GetConstructors();
+            var constructor = constructors.Length == 1 && constructors[0].GetParameters().Length > 0
+                ? constructors[0]
+                : null;
+
+            if (constructor != null)
+            {
+                foreach (var parameter in constructor.GetParameters())
+                {
+                    var attributes = parameter.GetCustomAttributes().ToList();
+                    var property = properties.FirstOrDefault(p =>
+                        string.Equals(p.Name, parameter.Name, StringComparison.OrdinalIgnoreCase));
+                    if (property != null)
+                    {
+                        covered.Add(property.Name);
+                        attributes.AddRange(property.GetCustomAttributes());
+                    }
+
+                    yield return new AsParametersMember(
+                        parameter.Name ?? string.Empty,
+                        parameter.ParameterType,
+                        attributes,
+                        parameter,
+                        property);
+                }
+            }
+
+            foreach (var property in properties)
+            {
+                if (covered.Contains(property.Name) || !property.CanWrite)
+                {
+                    continue;
+                }
+
+                yield return new AsParametersMember(
+                    property.Name,
+                    property.PropertyType,
+                    property.GetCustomAttributes().ToList(),
+                    null,
+                    property);
+            }
         }
 
         /// <summary>

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
@@ -40,12 +40,20 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             typeof(Stream),
         };
 
-        private static readonly string[] FormParameterTypeNames =
+        /// <summary>How a parameter participates in form binding, if it does at all.</summary>
+        internal enum FormParameterKind
         {
-            "Microsoft.AspNetCore.Http.IFormFile",
-            "Microsoft.AspNetCore.Http.IFormFileCollection",
-            "Microsoft.AspNetCore.Http.IFormCollection",
-        };
+            None,
+
+            /// <summary>A single <see cref="IFormFile"/>.</summary>
+            File,
+
+            /// <summary>An <see cref="IFormFileCollection"/> or any collection of <see cref="IFormFile"/>.</summary>
+            FileCollection,
+
+            /// <summary>The whole form, bound as <see cref="IFormCollection"/>.</summary>
+            FormCollection,
+        }
 
         private readonly IActionDescriptorCollectionProvider? _actionProvider;
         private readonly NabuMcpOptions _options;
@@ -781,9 +789,13 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 return methods[0].ToUpperInvariant();
             }
 
-            // No explicit verb: infer from whether anything is bound from the body.
+            // No explicit verb: infer from whether anything is bound from the body or the form.
             var hasBody = action.Parameters.Any(p =>
-                p.BindingInfo?.BindingSource != null && p.BindingInfo.BindingSource.Id == BindingSource.Body.Id);
+                (p.BindingInfo?.BindingSource != null &&
+                 (p.BindingInfo.BindingSource.Id == BindingSource.Body.Id ||
+                  p.BindingInfo.BindingSource.Id == BindingSource.Form.Id ||
+                  p.BindingInfo.BindingSource.Id == BindingSource.FormFile.Id)) ||
+                GetFormParameterKind(p.ParameterType) != FormParameterKind.None);
 
             return hasBody ? "POST" : "GET";
         }
@@ -839,14 +851,40 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     continue;
                 }
 
-                if (IsFormType(parameter.ParameterType))
+                var bindingName = parameter.BindingInfo?.BinderModelName ?? parameter.Name;
+                var formKind = GetFormParameterKind(parameter.ParameterType);
+
+                if (formKind == FormParameterKind.File || formKind == FormParameterKind.FileCollection)
                 {
-                    _logger.LogWarning(
-                        "Nabu MCP skipped {Controller}.{Action}: parameter '{Parameter}' binds form data, which tools cannot supply.",
-                        action.ControllerName,
-                        action.ActionName,
-                        parameter.Name);
-                    return false;
+                    AddParameter(
+                        action.MethodInfo,
+                        parameter.Name,
+                        bindingName,
+                        parameter.ParameterType,
+                        parameterInfo,
+                        McpParameterSource.FormFile,
+                        routeTemplate,
+                        parameters,
+                        seen,
+                        schemaOverride: BuildFileArgumentSchema(formKind == FormParameterKind.FileCollection));
+                    continue;
+                }
+
+                if (formKind == FormParameterKind.FormCollection)
+                {
+                    AddParameter(
+                        action.MethodInfo,
+                        parameter.Name,
+                        bindingName,
+                        parameter.ParameterType,
+                        parameterInfo,
+                        McpParameterSource.Form,
+                        routeTemplate,
+                        parameters,
+                        seen,
+                        schemaOverride: BuildFormCollectionSchema(),
+                        isFormRoot: true);
+                    continue;
                 }
 
                 var source = parameter.BindingInfo?.BindingSource;
@@ -858,16 +896,6 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                         continue;
                     }
 
-                    if (source.Id == BindingSource.Form.Id || source.Id == BindingSource.FormFile.Id)
-                    {
-                        _logger.LogWarning(
-                            "Nabu MCP skipped {Controller}.{Action}: parameter '{Parameter}' binds form data.",
-                            action.ControllerName,
-                            action.ActionName,
-                            parameter.Name);
-                        return false;
-                    }
-
                     if (source.Id == BindingSource.Header.Id && !_options.ExposeHeaderParameters)
                     {
                         continue;
@@ -875,7 +903,6 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 }
 
                 var resolved = ResolveSource(source, parameter, parameterInfo, httpMethod, routeTemplate);
-                var bindingName = parameter.BindingInfo?.BinderModelName ?? parameter.Name;
                 AddParameter(
                     action.MethodInfo,
                     parameter.Name,
@@ -919,6 +946,16 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 {
                     return McpParameterSource.Header;
                 }
+
+                if (source.Id == BindingSource.Form.Id)
+                {
+                    return McpParameterSource.Form;
+                }
+
+                if (source.Id == BindingSource.FormFile.Id)
+                {
+                    return McpParameterSource.FormFile;
+                }
             }
 
             var bindingName = parameter.BindingInfo?.BinderModelName ?? parameter.Name;
@@ -946,19 +983,30 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             string routeTemplate,
             List<McpToolParameterDescriptor> parameters,
             ISet<string> seen,
-            bool valueTypesDefaultToOptional = true)
+            bool valueTypesDefaultToOptional = true,
+            PropertyInfo? propertyInfo = null,
+            JsonObject? schemaOverride = null,
+            bool isFormRoot = false)
         {
             var attributes = parameterInfo?.GetCustomAttributes().ToList() ?? new List<Attribute>();
-            var mcpAttribute = parameterInfo?.GetCustomAttribute<McpParameterAttribute>();
+            if (propertyInfo != null)
+            {
+                attributes.AddRange(propertyInfo.GetCustomAttributes());
+            }
+
+            var mcpAttribute = attributes.OfType<McpParameterAttribute>().FirstOrDefault();
 
             var description = JsonSchemaGenerator.ReadDescription(attributes)
                               ?? (documentationMethod != null
                                   ? _documentation.GetParameterDescription(documentationMethod, parameterName)
-                                  : null);
+                                  : null)
+                              ?? (propertyInfo != null ? _documentation.GetSummary(propertyInfo) : null);
 
             var isComplex = JsonSchemaGenerator.IsComplexObject(type);
-            var shouldFlatten = isComplex &&
+            var shouldFlatten = schemaOverride == null &&
+                                isComplex &&
                                 (source == McpParameterSource.Query ||
+                                 source == McpParameterSource.Form ||
                                  (source == McpParameterSource.Body && _options.FlattenBodyParameter));
 
             if (shouldFlatten)
@@ -969,6 +1017,28 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                     foreach (var property in properties)
                     {
                         var name = Deduplicate(property.Name, seen);
+
+                        // A file-typed property of a form model stays a file argument: it becomes a
+                        // multipart part named after the property, which is where model binding looks.
+                        var propertyKind = source == McpParameterSource.Form
+                            ? GetFormParameterKind(property.ClrType)
+                            : FormParameterKind.None;
+
+                        if (propertyKind == FormParameterKind.File || propertyKind == FormParameterKind.FileCollection)
+                        {
+                            parameters.Add(new McpToolParameterDescriptor(
+                                name,
+                                property.Name,
+                                McpParameterSource.FormFile,
+                                property.ClrType,
+                                property.IsRequired,
+                                BuildFileArgumentSchema(propertyKind == FormParameterKind.FileCollection))
+                            {
+                                Description = property.Description,
+                            });
+                            continue;
+                        }
+
                         parameters.Add(new McpToolParameterDescriptor(
                             name,
                             property.Name,
@@ -992,8 +1062,10 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 source == McpParameterSource.Header ? parameterName : bindingName);
             schemaName = Deduplicate(schemaName, seen);
 
-            var nullable = parameterInfo != null ? NullabilityHelper.IsNullable(parameterInfo) : null;
-            var schema = _schemaGenerator.Generate(type, attributes, nullable);
+            var nullable = parameterInfo != null
+                ? NullabilityHelper.IsNullable(parameterInfo)
+                : propertyInfo != null ? NullabilityHelper.IsNullable(propertyInfo) : null;
+            var schema = schemaOverride ?? _schemaGenerator.Generate(type, attributes, nullable);
 
             if (!string.IsNullOrEmpty(description) && schema["description"] == null)
             {
@@ -1001,11 +1073,19 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             }
 
             var isRequired = ResolveRequired(
-                type, parameterInfo, attributes, mcpAttribute, source, routeTemplate, bindingName, nullable, valueTypesDefaultToOptional);
+                type,
+                parameterInfo?.HasDefaultValue == true,
+                attributes,
+                mcpAttribute,
+                source,
+                routeTemplate,
+                bindingName,
+                nullable,
+                valueTypesDefaultToOptional);
 
             parameters.Add(new McpToolParameterDescriptor(schemaName, bindingName, source, type, isRequired, schema)
             {
-                IsBodyRoot = source == McpParameterSource.Body,
+                IsBodyRoot = source == McpParameterSource.Body || isFormRoot,
                 Description = description,
             });
         }
@@ -1037,7 +1117,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         /// </remarks>
         private static bool ResolveRequired(
             Type parameterType,
-            ParameterInfo? parameterInfo,
+            bool hasDefaultValue,
             IList<Attribute> attributes,
             McpParameterAttribute? mcpAttribute,
             McpParameterSource source,
@@ -1056,7 +1136,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 return true;
             }
 
-            if (parameterInfo != null && parameterInfo.HasDefaultValue)
+            if (hasDefaultValue)
             {
                 return false;
             }
@@ -1066,7 +1146,7 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 return RouteTemplateHelper.ContainsToken(routeTemplate, bindingName);
             }
 
-            if (source == McpParameterSource.Body)
+            if (source == McpParameterSource.Body || source == McpParameterSource.FormFile)
             {
                 return nullable != true;
             }
@@ -1121,33 +1201,83 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             return false;
         }
 
-        private static bool IsFormType(Type type)
+        internal static FormParameterKind GetFormParameterKind(Type type)
         {
-            var candidates = new List<Type> { type };
+            if (typeof(IFormFile).IsAssignableFrom(type))
+            {
+                return FormParameterKind.File;
+            }
+
+            if (typeof(IFormFileCollection).IsAssignableFrom(type))
+            {
+                return FormParameterKind.FileCollection;
+            }
+
             var element = JsonSchemaGenerator.GetEnumerableElementType(type);
-            if (element != null)
+            if (element != null && typeof(IFormFile).IsAssignableFrom(element))
             {
-                candidates.Add(element);
+                return FormParameterKind.FileCollection;
             }
 
-            foreach (var candidate in candidates)
+            if (typeof(IFormCollection).IsAssignableFrom(type))
             {
-                var name = candidate.FullName;
-                if (name != null && Array.IndexOf(FormParameterTypeNames, name) >= 0)
-                {
-                    return true;
-                }
+                return FormParameterKind.FormCollection;
+            }
 
-                foreach (var @interface in candidate.GetInterfaces())
+            return FormParameterKind.None;
+        }
+
+        /// <summary>
+        /// The schema advertised for a file argument. The caller supplies the content base64-encoded;
+        /// the binder turns it into a part of a multipart/form-data body, which the action's own model
+        /// binding reads back as an <see cref="IFormFile"/>.
+        /// </summary>
+        internal static JsonObject BuildFileSchema()
+        {
+            return new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
                 {
-                    if (@interface.FullName != null && Array.IndexOf(FormParameterTypeNames, @interface.FullName) >= 0)
+                    ["data"] = new JsonObject
                     {
-                        return true;
-                    }
-                }
-            }
+                        ["type"] = "string",
+                        ["contentEncoding"] = "base64",
+                        ["description"] = "The file content, base64-encoded.",
+                    },
+                    ["fileName"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "The file name reported to the endpoint.",
+                    },
+                    ["contentType"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "The MIME type of the content. Defaults to application/octet-stream.",
+                    },
+                },
+                ["required"] = new JsonArray("data"),
+            };
+        }
 
-            return false;
+        /// <summary>The file schema, or an array of it for a collection-of-files parameter.</summary>
+        internal static JsonObject BuildFileArgumentSchema(bool isCollection)
+        {
+            var schema = BuildFileSchema();
+            return isCollection
+                ? new JsonObject { ["type"] = "array", ["items"] = schema }
+                : schema;
+        }
+
+        /// <summary>The schema advertised for a whole-form argument (<see cref="IFormCollection"/>).</summary>
+        internal static JsonObject BuildFormCollectionSchema()
+        {
+            return new JsonObject
+            {
+                ["type"] = "object",
+                ["description"] = "Form fields as name/value pairs. Array values repeat the field.",
+                ["additionalProperties"] = new JsonObject(),
+            };
         }
     }
 }

--- a/src/Nabu.Mcp.AspNetCore/Execution/FormBodyEncoder.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/FormBodyEncoder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Nabu.Mcp.AspNetCore.Execution
+{
+    /// <summary>
+    /// Renders the bound form data of a tool call as an HTTP request body: multipart/form-data when a
+    /// file is present, application/x-www-form-urlencoded otherwise. The synthetic request carries the
+    /// matching <c>Content-Type</c>, so the action's own form model binding reads it back exactly as it
+    /// would a browser upload.
+    /// </summary>
+    internal static class FormBodyEncoder
+    {
+        public static byte[] Encode(McpArgumentBinder.BoundRequest bound, out string contentType)
+        {
+            if (bound.FormFiles.Count == 0)
+            {
+                contentType = "application/x-www-form-urlencoded; charset=utf-8";
+                return EncodeUrlEncoded(bound);
+            }
+
+            var boundary = "nabu-mcp-" + Guid.NewGuid().ToString("N");
+            contentType = "multipart/form-data; boundary=" + boundary;
+            return EncodeMultipart(bound, boundary);
+        }
+
+        private static byte[] EncodeUrlEncoded(McpArgumentBinder.BoundRequest bound)
+        {
+            var builder = new StringBuilder();
+            foreach (var field in bound.FormFields)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append('&');
+                }
+
+                builder.Append(Uri.EscapeDataString(field.Key))
+                       .Append('=')
+                       .Append(Uri.EscapeDataString(field.Value));
+            }
+
+            return Encoding.UTF8.GetBytes(builder.ToString());
+        }
+
+        private static byte[] EncodeMultipart(McpArgumentBinder.BoundRequest bound, string boundary)
+        {
+            using (var stream = new MemoryStream())
+            {
+                foreach (var field in bound.FormFields)
+                {
+                    WriteText(stream, "--" + boundary + "\r\n");
+                    WriteText(
+                        stream,
+                        "Content-Disposition: form-data; name=\"" + EscapeHeaderValue(field.Key) + "\"\r\n\r\n");
+                    WriteText(stream, field.Value);
+                    WriteText(stream, "\r\n");
+                }
+
+                foreach (var file in bound.FormFiles)
+                {
+                    WriteText(stream, "--" + boundary + "\r\n");
+                    WriteText(
+                        stream,
+                        "Content-Disposition: form-data; name=\"" + EscapeHeaderValue(file.Name) +
+                        "\"; filename=\"" + EscapeHeaderValue(file.FileName) + "\"\r\n");
+                    WriteText(stream, "Content-Type: " + file.ContentType + "\r\n\r\n");
+                    stream.Write(file.Content, 0, file.Content.Length);
+                    WriteText(stream, "\r\n");
+                }
+
+                WriteText(stream, "--" + boundary + "--\r\n");
+                return stream.ToArray();
+            }
+        }
+
+        private static void WriteText(Stream stream, string text)
+        {
+            var bytes = Encoding.UTF8.GetBytes(text);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        /// <summary>
+        /// Field and file names land inside a quoted Content-Disposition value; quotes and line breaks
+        /// would corrupt the part header, so they are percent-encoded the way browsers do it.
+        /// </summary>
+        private static string EscapeHeaderValue(string value)
+        {
+            return value
+                .Replace("\"", "%22")
+                .Replace("\r", "%0D")
+                .Replace("\n", "%0A");
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpArgumentBinder.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpArgumentBinder.cs
@@ -19,6 +19,19 @@ namespace Nabu.Mcp.AspNetCore.Execution
 
             public JsonNode? Body { get; set; }
 
+            /// <summary>
+            /// True when the target endpoint binds form data. The request body is then built from
+            /// <see cref="FormFields"/> and <see cref="FormFiles"/> - multipart/form-data when a file
+            /// is present, application/x-www-form-urlencoded otherwise - and <see cref="Body"/> is ignored.
+            /// </summary>
+            public bool IsForm { get; set; }
+
+            /// <summary>Form fields, in write order. A repeated key sends the field several times.</summary>
+            public IList<KeyValuePair<string, string>> FormFields { get; } = new List<KeyValuePair<string, string>>();
+
+            /// <summary>Decoded file parts for the multipart/form-data body.</summary>
+            public IList<McpFormFilePart> FormFiles { get; } = new List<McpFormFilePart>();
+
             public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             /// <summary>
@@ -28,6 +41,27 @@ namespace Nabu.Mcp.AspNetCore.Execution
             public ISet<string> ConstantHeaders { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>One file of a multipart/form-data request, decoded from a tool argument.</summary>
+        public sealed class McpFormFilePart
+        {
+            public McpFormFilePart(string name, string fileName, string contentType, byte[] content)
+            {
+                Name = name;
+                FileName = fileName;
+                ContentType = contentType;
+                Content = content;
+            }
+
+            /// <summary>The form field name the action's model binding looks for.</summary>
+            public string Name { get; }
+
+            public string FileName { get; }
+
+            public string ContentType { get; }
+
+            public byte[] Content { get; }
+        }
+
         public static BoundRequest Bind(McpToolDescriptor tool, JsonObject? arguments, Schema.McpJsonCompatibility compatibility)
         {
             var result = new BoundRequest();
@@ -35,6 +69,27 @@ namespace Nabu.Mcp.AspNetCore.Execution
             var query = new List<KeyValuePair<string, string>>();
             JsonObject? bodyObject = null;
             JsonNode? bodyRoot = null;
+
+            foreach (var parameter in tool.Parameters)
+            {
+                if (parameter.Source == McpParameterSource.Form || parameter.Source == McpParameterSource.FormFile)
+                {
+                    result.IsForm = true;
+                    break;
+                }
+            }
+
+            if (!result.IsForm)
+            {
+                foreach (var constant in tool.Constants)
+                {
+                    if (constant.Source == McpParameterSource.Form || constant.Source == McpParameterSource.FormFile)
+                    {
+                        result.IsForm = true;
+                        break;
+                    }
+                }
+            }
 
             foreach (var parameter in tool.Parameters)
             {
@@ -146,6 +201,56 @@ namespace Nabu.Mcp.AspNetCore.Execution
                         }
 
                         break;
+
+                    case McpParameterSource.Form:
+                        if (isBodyRoot)
+                        {
+                            // The argument is the whole form (IFormCollection): every property of the
+                            // supplied object becomes a field of its own.
+                            if (value is JsonObject formRoot)
+                            {
+                                foreach (var property in formRoot)
+                                {
+                                    if (replaceExisting)
+                                    {
+                                        RemoveFields(result.FormFields, property.Key);
+                                    }
+
+                                    AppendQuery(result.FormFields, property.Key, property.Value);
+                                }
+                            }
+                            else if (value != null)
+                            {
+                                throw new McpArgumentException(
+                                    "Argument '" + bindingName + "' for tool '" + tool.Name + "' must be an object of form fields.");
+                            }
+                        }
+                        else
+                        {
+                            if (replaceExisting)
+                            {
+                                RemoveFields(result.FormFields, bindingName);
+                            }
+
+                            AppendQuery(result.FormFields, bindingName, value);
+                        }
+
+                        break;
+
+                    case McpParameterSource.FormFile:
+                        if (replaceExisting)
+                        {
+                            for (var i = result.FormFiles.Count - 1; i >= 0; i--)
+                            {
+                                if (string.Equals(result.FormFiles[i].Name, bindingName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    result.FormFiles.RemoveAt(i);
+                                }
+                            }
+                        }
+
+                        AppendFiles(result.FormFiles, tool.Name, bindingName, value);
+                        break;
                 }
             }
 
@@ -159,6 +264,101 @@ namespace Nabu.Mcp.AspNetCore.Execution
             result.Body = bodyRoot ?? bodyObject;
 
             return result;
+        }
+
+        private static void RemoveFields(IList<KeyValuePair<string, string>> fields, string key)
+        {
+            for (var i = fields.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(fields[i].Key, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    fields.RemoveAt(i);
+                }
+            }
+        }
+
+        private static void AppendFiles(ICollection<McpFormFilePart> files, string toolName, string name, JsonNode? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            if (value is JsonArray array)
+            {
+                foreach (var item in array)
+                {
+                    if (item != null)
+                    {
+                        files.Add(ParseFilePart(toolName, name, item));
+                    }
+                }
+
+                return;
+            }
+
+            files.Add(ParseFilePart(toolName, name, value));
+        }
+
+        /// <summary>
+        /// Decodes one file argument: either an object carrying base64 <c>data</c> with an optional
+        /// <c>fileName</c> and <c>contentType</c>, or - leniently - a bare base64 string.
+        /// </summary>
+        private static McpFormFilePart ParseFilePart(string toolName, string name, JsonNode value)
+        {
+            string? data;
+            string? fileName = null;
+            string? contentType = null;
+
+            if (value is JsonObject obj)
+            {
+                data = StringProperty(obj, "data");
+                fileName = StringProperty(obj, "fileName");
+                contentType = StringProperty(obj, "contentType");
+
+                if (data == null)
+                {
+                    throw new McpArgumentException(
+                        "File argument '" + name + "' for tool '" + toolName + "' is missing its base64 'data' property.");
+                }
+            }
+            else if (value.GetValueKind() == JsonValueKind.String)
+            {
+                data = value.GetValue<string>();
+            }
+            else
+            {
+                throw new McpArgumentException(
+                    "File argument '" + name + "' for tool '" + toolName + "' must be an object with a base64 'data' property.");
+            }
+
+            byte[] content;
+            try
+            {
+                content = Convert.FromBase64String(data);
+            }
+            catch (FormatException)
+            {
+                throw new McpArgumentException(
+                    "File argument '" + name + "' for tool '" + toolName + "' does not contain valid base64 data.");
+            }
+
+            return new McpFormFilePart(
+                name,
+                string.IsNullOrEmpty(fileName) ? name : fileName!,
+                string.IsNullOrEmpty(contentType) ? "application/octet-stream" : contentType!,
+                content);
+        }
+
+        private static string? StringProperty(JsonObject obj, string name)
+        {
+            JsonNode? node;
+            if (!obj.TryGetPropertyValue(name, out node) || node == null)
+            {
+                return null;
+            }
+
+            return node.GetValueKind() == JsonValueKind.String ? node.GetValue<string>() : node.ToJsonString();
         }
 
         private static void AppendQuery(ICollection<KeyValuePair<string, string>> query, string key, JsonNode? value)

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpToolInvoker.cs
@@ -95,16 +95,24 @@ namespace Nabu.Mcp.AspNetCore.Execution
             var bound = McpArgumentBinder.Bind(tool, arguments, _compatibility);
 
             byte[]? bodyBytes = null;
-            if (bound.Body != null)
+            string? bodyContentType = null;
+            if (bound.IsForm)
+            {
+                // A form-binding endpoint always gets a form body - even an empty one - so that the
+                // action's ReadFormAsync sees a well-formed request rather than a missing content type.
+                bodyBytes = FormBodyEncoder.Encode(bound, out bodyContentType);
+            }
+            else if (bound.Body != null)
             {
                 bodyBytes = Encoding.UTF8.GetBytes(bound.Body.ToJsonString());
+                bodyContentType = McpConstants.JsonContentType + "; charset=utf-8";
             }
 
             using (var scope = _scopeFactory.CreateScope())
             using (var requestBody = bodyBytes == null ? Stream.Null : new MemoryStream(bodyBytes, writable: false))
             using (var responseBody = new CappedResponseStream(_options.MaxResponseBytes))
             {
-                var features = BuildFeatures(tool, originalContext, bound, bodyBytes, requestBody, responseBody, scope, cancellationToken);
+                var features = BuildFeatures(tool, originalContext, bound, bodyBytes, bodyContentType, requestBody, responseBody, scope, cancellationToken);
 
                 var previousAccessorContext = _httpContextAccessor?.HttpContext;
                 var context = _httpContextFactory != null
@@ -160,6 +168,7 @@ namespace Nabu.Mcp.AspNetCore.Execution
             HttpContext originalContext,
             McpArgumentBinder.BoundRequest bound,
             byte[]? bodyBytes,
+            string? bodyContentType,
             Stream requestBody,
             Stream responseBody,
             IServiceScope scope,
@@ -190,7 +199,7 @@ namespace Nabu.Mcp.AspNetCore.Execution
 
             if (bodyBytes != null)
             {
-                headers["Content-Type"] = McpConstants.JsonContentType + "; charset=utf-8";
+                headers["Content-Type"] = bodyContentType ?? McpConstants.JsonContentType + "; charset=utf-8";
                 headers["Content-Length"] = bodyBytes.Length.ToString(CultureInfo.InvariantCulture);
             }
 

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/AsParametersTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/AsParametersTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Nabu.Mcp.AspNetCore;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// Minimal API handlers that gather their inputs into an <c>[AsParameters]</c> surface type. The
+    /// type's constructor parameters and settable properties are expanded into individual tool inputs
+    /// with the same binding inference they get from <c>RequestDelegateFactory</c>.
+    /// </summary>
+    public class AsParametersTests
+    {
+        public record SearchRequest(string Category, string? Term, int Page = 1);
+
+        public class PagingParams
+        {
+            [FromQuery(Name = "q")]
+            public string? Query { get; set; }
+
+            public int? PageSize { get; set; }
+        }
+
+        public sealed class Clock
+        {
+            public string Now => "now";
+        }
+
+        public class WithService
+        {
+            public string? Term { get; set; }
+
+            [FromServices]
+            public Clock Clock { get; set; } = null!;
+        }
+
+        private static IHost CreateServer(
+            Action<IEndpointRouteBuilder> map,
+            Action<IServiceCollection>? services = null)
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(collection =>
+                    {
+                        collection.AddRouting();
+                        collection.AddNabuMcp();
+                        services?.Invoke(collection);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp();
+                        app.UseEndpoints(endpoints => map(endpoints));
+                    }))
+                .Build();
+
+            host.Start();
+            return host;
+        }
+
+        private static async Task<JsonObject> RpcAsync(IHost server, string method, JsonObject? parameters = null)
+        {
+            var request = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = method,
+            };
+
+            if (parameters != null)
+            {
+                request["params"] = parameters;
+            }
+
+            using var client = server.GetTestClient();
+            using var response = await client.PostAsync(
+                "/mcp",
+                new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json"));
+
+            return JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        }
+
+        private static async Task<JsonObject?> FindToolAsync(IHost server, string name)
+        {
+            var envelope = await RpcAsync(server, "tools/list");
+            return envelope["result"]!["tools"]!.AsArray()
+                .Select(t => t!.AsObject())
+                .FirstOrDefault(t => t["name"]!.GetValue<string>() == name);
+        }
+
+        private static async Task<JsonNode> CallAsync(IHost server, string name, JsonObject arguments)
+        {
+            var envelope = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject { ["name"] = name, ["arguments"] = arguments });
+
+            Assert.True(envelope["error"] == null, "tools/call returned an error: " + envelope["error"]?.ToJsonString());
+
+            var result = envelope["result"]!.AsObject();
+            Assert.False(result["isError"]?.GetValue<bool>() ?? false, "tool result was an error: " + result.ToJsonString());
+
+            return JsonNode.Parse(result["content"]!.AsArray()[0]!["text"]!.GetValue<string>())!;
+        }
+
+        [Fact]
+        public async Task A_record_is_expanded_into_route_and_query_inputs()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/search/{category}", ([AsParameters] SearchRequest request) =>
+                        Results.Ok(new { request.Category, request.Term, request.Page }))
+                    .McpTool("search"));
+
+            var tool = await FindToolAsync(server, "search");
+            Assert.NotNull(tool);
+
+            var schema = tool!["inputSchema"]!.AsObject();
+            var properties = schema["properties"]!.AsObject();
+
+            // The surface type is gone: its members are individual inputs.
+            Assert.Null(properties["request"]);
+            Assert.NotNull(properties["category"]);
+            Assert.NotNull(properties["term"]);
+            Assert.NotNull(properties["page"]);
+
+            var required = schema["required"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray();
+            Assert.Contains("category", required);      // route token
+            Assert.DoesNotContain("term", required);    // nullable
+            Assert.DoesNotContain("page", required);    // has a default value
+
+            var body = await CallAsync(server, "search", new JsonObject
+            {
+                ["category"] = "books",
+                ["term"] = "assyriology",
+            });
+
+            Assert.Equal("books", body["category"]!.GetValue<string>());
+            Assert.Equal("assyriology", body["term"]!.GetValue<string>());
+            Assert.Equal(1, body["page"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_property_based_class_is_expanded_and_FromQuery_names_are_honoured()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapGet("/items", ([AsParameters] PagingParams paging) =>
+                        Results.Ok(new { paging.Query, paging.PageSize }))
+                    .McpTool("items"));
+
+            var tool = await FindToolAsync(server, "items");
+            Assert.NotNull(tool);
+
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+            Assert.NotNull(properties["q"]);
+            Assert.NotNull(properties["pageSize"]);
+
+            var body = await CallAsync(server, "items", new JsonObject
+            {
+                ["q"] = "lamp",
+                ["pageSize"] = 5,
+            });
+
+            Assert.Equal("lamp", body["query"]!.GetValue<string>());
+            Assert.Equal(5, body["pageSize"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_FromServices_member_is_not_a_tool_input()
+        {
+            using var server = CreateServer(
+                endpoints =>
+                    endpoints.MapGet("/svc", ([AsParameters] WithService request) =>
+                            Results.Ok(new { request.Term, now = request.Clock.Now }))
+                        .McpTool("svc"),
+                services: collection => collection.AddSingleton<Clock>());
+
+            var tool = await FindToolAsync(server, "svc");
+            Assert.NotNull(tool);
+
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+            Assert.NotNull(properties["term"]);
+            Assert.Null(properties["clock"]);
+
+            var body = await CallAsync(server, "svc", new JsonObject { ["term"] = "x" });
+
+            Assert.Equal("x", body["term"]!.GetValue<string>());
+            Assert.Equal("now", body["now"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task An_AsParameters_type_can_carry_a_file()
+        {
+            using var server = CreateServer(endpoints =>
+                endpoints.MapPost("/upload/{folder}", ([AsParameters] UploadRequest request) =>
+                        Results.Ok(new { request.Folder, name = request.File.FileName }))
+                    .DisableAntiforgery()
+                    .McpTool("upload"));
+
+            var tool = await FindToolAsync(server, "upload");
+            Assert.NotNull(tool);
+
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+            Assert.NotNull(properties["folder"]);
+            Assert.Equal("base64", properties["file"]!["properties"]!["data"]!["contentEncoding"]!.GetValue<string>());
+
+            var body = await CallAsync(server, "upload", new JsonObject
+            {
+                ["folder"] = "docs",
+                ["file"] = new JsonObject
+                {
+                    ["data"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("payload")),
+                    ["fileName"] = "notes.md",
+                },
+            });
+
+            Assert.Equal("docs", body["folder"]!.GetValue<string>());
+            Assert.Equal("notes.md", body["name"]!.GetValue<string>());
+        }
+
+        public class UploadRequest
+        {
+            public string Folder { get; set; } = string.Empty;
+
+            public IFormFile File { get; set; } = null!;
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/FormBindingTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/FormBindingTests.cs
@@ -1,0 +1,391 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Nabu.Mcp.AspNetCore;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>Controllers used only by <see cref="FormBindingTests"/>.</summary>
+    [ApiController]
+    [Route("api/files")]
+    public class FormUploadController : ControllerBase
+    {
+        [HttpPost("upload")]
+        [McpTool("files_upload")]
+        public IActionResult Upload([FromForm] string title, IFormFile file)
+        {
+            using var reader = new StreamReader(file.OpenReadStream());
+            return Ok(new
+            {
+                title,
+                file.FileName,
+                file.ContentType,
+                content = reader.ReadToEnd(),
+            });
+        }
+
+        [HttpPost("product")]
+        [McpTool("files_product")]
+        public IActionResult Product([FromForm] ProductForm form)
+        {
+            return Ok(new
+            {
+                form.Name,
+                form.Quantity,
+                imageName = form.Image?.FileName,
+            });
+        }
+
+        public class ProductForm
+        {
+            public string Name { get; set; } = string.Empty;
+
+            public int Quantity { get; set; }
+
+            public IFormFile? Image { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Endpoints that bind form data - <see cref="IFormFile"/>, <c>[FromForm]</c> fields and models,
+    /// <see cref="IFormCollection"/> - published as tools. The caller supplies file content as base64;
+    /// the invoker replays it as a real multipart/form-data (or urlencoded) request, so the action's
+    /// own form model binding does the rest.
+    /// </summary>
+    public class FormBindingTests
+    {
+        private static IHost CreateMinimalServer(Action<IEndpointRouteBuilder> map)
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(collection =>
+                    {
+                        collection.AddRouting();
+                        collection.AddNabuMcp();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp();
+                        app.UseEndpoints(endpoints => map(endpoints));
+                    }))
+                .Build();
+
+            host.Start();
+            return host;
+        }
+
+        private static IHost CreateControllerServer()
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseTestServer()
+                    .ConfigureServices(collection =>
+                    {
+                        collection
+                            .AddControllers()
+                            .AddApplicationPart(typeof(FormUploadController).Assembly)
+                            .OnlyControllers(typeof(FormUploadController));
+
+                        collection.AddNabuMcp();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseNabuMcp();
+                        app.UseEndpoints(endpoints => endpoints.MapControllers());
+                    }))
+                .Build();
+
+            host.Start();
+            return host;
+        }
+
+        private static async Task<JsonObject> RpcAsync(IHost server, string method, JsonObject? parameters = null)
+        {
+            var request = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 1,
+                ["method"] = method,
+            };
+
+            if (parameters != null)
+            {
+                request["params"] = parameters;
+            }
+
+            using var client = server.GetTestClient();
+            using var response = await client.PostAsync(
+                "/mcp",
+                new StringContent(request.ToJsonString(), Encoding.UTF8, "application/json"));
+
+            return JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        }
+
+        private static async Task<JsonObject?> FindToolAsync(IHost server, string name)
+        {
+            var envelope = await RpcAsync(server, "tools/list");
+            return envelope["result"]!["tools"]!.AsArray()
+                .Select(t => t!.AsObject())
+                .FirstOrDefault(t => t["name"]!.GetValue<string>() == name);
+        }
+
+        private static async Task<JsonNode> CallAsync(IHost server, string name, JsonObject arguments)
+        {
+            var envelope = await RpcAsync(
+                server,
+                "tools/call",
+                new JsonObject { ["name"] = name, ["arguments"] = arguments });
+
+            Assert.True(envelope["error"] == null, "tools/call returned an error: " + envelope["error"]?.ToJsonString());
+
+            var result = envelope["result"]!.AsObject();
+            Assert.False(result["isError"]?.GetValue<bool>() ?? false, "tool result was an error: " + result.ToJsonString());
+
+            return JsonNode.Parse(result["content"]!.AsArray()[0]!["text"]!.GetValue<string>())!;
+        }
+
+        private static string Base64(string text) => Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
+
+        [Fact]
+        public async Task An_IFormFile_parameter_is_advertised_as_a_base64_file_argument()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/upload", (IFormFile file) => Results.Ok(new { file.FileName }))
+                         .DisableAntiforgery()
+                         .McpTool("upload_file"));
+
+            var tool = await FindToolAsync(server, "upload_file");
+            Assert.NotNull(tool);
+
+            var schema = tool!["inputSchema"]!.AsObject();
+            var file = schema["properties"]!["file"]!.AsObject();
+
+            Assert.Equal("object", file["type"]!.GetValue<string>());
+            Assert.Equal("base64", file["properties"]!["data"]!["contentEncoding"]!.GetValue<string>());
+            Assert.Contains("data", file["required"]!.AsArray().Select(n => n!.GetValue<string>()));
+            Assert.Contains("file", schema["required"]!.AsArray().Select(n => n!.GetValue<string>()));
+        }
+
+        [Fact]
+        public async Task A_minimal_api_file_upload_round_trips_through_the_pipeline()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/upload", async (IFormFile file, [FromForm] string title) =>
+                    {
+                        using var reader = new StreamReader(file.OpenReadStream());
+                        return Results.Ok(new
+                        {
+                            title,
+                            file.FileName,
+                            file.ContentType,
+                            content = await reader.ReadToEndAsync(),
+                        });
+                    })
+                    .DisableAntiforgery()
+                    .McpTool("upload_file"));
+
+            var body = await CallAsync(server, "upload_file", new JsonObject
+            {
+                ["title"] = "Quarterly report",
+                ["file"] = new JsonObject
+                {
+                    ["data"] = Base64("hello, nabu"),
+                    ["fileName"] = "report.txt",
+                    ["contentType"] = "text/plain",
+                },
+            });
+
+            Assert.Equal("Quarterly report", body["title"]!.GetValue<string>());
+            Assert.Equal("report.txt", body["fileName"]!.GetValue<string>());
+            Assert.Equal("text/plain", body["contentType"]!.GetValue<string>());
+            Assert.Equal("hello, nabu", body["content"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task A_bare_base64_string_is_accepted_and_defaults_are_applied()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/upload", (IFormFile file) =>
+                        Results.Ok(new { file.FileName, file.ContentType, size = file.Length }))
+                    .DisableAntiforgery()
+                    .McpTool("upload_file"));
+
+            var body = await CallAsync(server, "upload_file", new JsonObject
+            {
+                ["file"] = Base64("abc"),
+            });
+
+            Assert.Equal("file", body["fileName"]!.GetValue<string>());
+            Assert.Equal("application/octet-stream", body["contentType"]!.GetValue<string>());
+            Assert.Equal(3, body["size"]!.GetValue<long>());
+        }
+
+        [Fact]
+        public async Task A_collection_of_files_becomes_an_array_argument()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/upload-many", (IFormFileCollection files) =>
+                        Results.Ok(new { names = files.Select(f => f.FileName).ToArray() }))
+                    .DisableAntiforgery()
+                    .McpTool("upload_many"));
+
+            var tool = await FindToolAsync(server, "upload_many");
+            Assert.Equal("array", tool!["inputSchema"]!["properties"]!["files"]!["type"]!.GetValue<string>());
+
+            var body = await CallAsync(server, "upload_many", new JsonObject
+            {
+                ["files"] = new JsonArray(
+                    new JsonObject { ["data"] = Base64("one"), ["fileName"] = "a.txt" },
+                    new JsonObject { ["data"] = Base64("two"), ["fileName"] = "b.txt" }),
+            });
+
+            Assert.Equal(new[] { "a.txt", "b.txt" }, body["names"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray());
+        }
+
+        [Fact]
+        public async Task Form_fields_without_files_are_sent_urlencoded()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/register", ([FromForm] string name, [FromForm] int age) =>
+                        Results.Ok(new { name, age }))
+                    .DisableAntiforgery()
+                    .McpTool("register"));
+
+            var body = await CallAsync(server, "register", new JsonObject
+            {
+                ["name"] = "Ada",
+                ["age"] = 36,
+            });
+
+            Assert.Equal("Ada", body["name"]!.GetValue<string>());
+            Assert.Equal(36, body["age"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task Invalid_base64_is_an_invalid_params_error_not_a_crash()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/upload", (IFormFile file) => Results.Ok())
+                    .DisableAntiforgery()
+                    .McpTool("upload_file"));
+
+            var envelope = await RpcAsync(server, "tools/call", new JsonObject
+            {
+                ["name"] = "upload_file",
+                ["arguments"] = new JsonObject
+                {
+                    ["file"] = new JsonObject { ["data"] = "not base64 at all!" },
+                },
+            });
+
+            Assert.Equal(-32602, envelope["error"]!["code"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public async Task A_controller_action_with_FromForm_and_IFormFile_is_published_and_invokable()
+        {
+            using var server = CreateControllerServer();
+
+            var tool = await FindToolAsync(server, "files_upload");
+            Assert.NotNull(tool);
+
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+            Assert.NotNull(properties["title"]);
+            Assert.NotNull(properties["file"]);
+
+            var body = await CallAsync(server, "files_upload", new JsonObject
+            {
+                ["title"] = "Invoice",
+                ["file"] = new JsonObject
+                {
+                    ["data"] = Base64("controller upload"),
+                    ["fileName"] = "invoice.pdf",
+                    ["contentType"] = "application/pdf",
+                },
+            });
+
+            Assert.Equal("Invoice", body["title"]!.GetValue<string>());
+            Assert.Equal("invoice.pdf", body["fileName"]!.GetValue<string>());
+            Assert.Equal("controller upload", body["content"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task A_FromForm_model_is_flattened_and_its_file_property_stays_a_file_argument()
+        {
+            using var server = CreateControllerServer();
+
+            var tool = await FindToolAsync(server, "files_product");
+            Assert.NotNull(tool);
+
+            var properties = tool!["inputSchema"]!["properties"]!.AsObject();
+
+            // The model's scalar properties are lifted to the top level; the wrapper is gone.
+            Assert.NotNull(properties["name"]);
+            Assert.NotNull(properties["quantity"]);
+            Assert.Null(properties["form"]);
+
+            // The file-typed property is advertised as a file argument, not as a nested object dump.
+            Assert.Equal("base64", properties["image"]!["properties"]!["data"]!["contentEncoding"]!.GetValue<string>());
+
+            var body = await CallAsync(server, "files_product", new JsonObject
+            {
+                ["name"] = "Widget",
+                ["quantity"] = 7,
+                ["image"] = new JsonObject { ["data"] = Base64("png-ish"), ["fileName"] = "widget.png" },
+            });
+
+            Assert.Equal("Widget", body["name"]!.GetValue<string>());
+            Assert.Equal(7, body["quantity"]!.GetValue<int>());
+            Assert.Equal("widget.png", body["imageName"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task An_optional_file_can_be_omitted()
+        {
+            using var server = CreateControllerServer();
+
+            var body = await CallAsync(server, "files_product", new JsonObject
+            {
+                ["name"] = "Widget",
+                ["quantity"] = 1,
+            });
+
+            Assert.Equal("Widget", body["name"]!.GetValue<string>());
+            Assert.True(body["imageName"] == null || body["imageName"]!.GetValueKind() == System.Text.Json.JsonValueKind.Null);
+        }
+
+        [Fact]
+        public async Task An_IFormCollection_parameter_accepts_a_free_form_object()
+        {
+            using var server = CreateMinimalServer(endpoints =>
+                endpoints.MapPost("/fields", (IFormCollection form) =>
+                        Results.Ok(new { color = form["color"].ToString(), size = form["size"].ToString() }))
+                    .DisableAntiforgery()
+                    .McpTool("fields"));
+
+            var body = await CallAsync(server, "fields", new JsonObject
+            {
+                ["form"] = new JsonObject { ["color"] = "red", ["size"] = 42 },
+            });
+
+            Assert.Equal("red", body["color"]!.GetValue<string>());
+            Assert.Equal("42", body["size"]!.GetValue<string>());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for form data binding and `[AsParameters]` surface types in Minimal API tools, enabling file uploads and complex form submissions through the MCP protocol.

## Key Changes

- **Form Data Binding**: Added support for `IFormFile`, `IFormFileCollection`, `[FromForm]` parameters, and `IFormCollection` in Minimal APIs. File arguments are transmitted as base64-encoded data and replayed as multipart/form-data requests.

- **[AsParameters] Expansion**: Implemented full support for `[AsParameters]` surface types in Minimal APIs. Constructor parameters and settable properties are now expanded into individual tool inputs with the same binding inference they receive from `RequestDelegateFactory`.

- **File Upload Schema**: Files are advertised in tool schemas as objects with `data` (base64-encoded), `fileName`, and `contentType` properties. Collections of files become array arguments.

- **Form Body Encoding**: Added `FormBodyEncoder` to render bound form data as either `application/x-www-form-urlencoded` (for fields only) or `multipart/form-data` (when files are present).

- **Argument Binding**: Extended `McpArgumentBinder` to handle form fields and files, with proper base64 decoding and validation of file data.

- **HTTP Method Inference**: Updated method inference logic to treat form-binding endpoints as POST (previously only body binding triggered POST).

- **Comprehensive Tests**: Added `FormBindingTests` and `AsParametersTests` integration test suites covering:
  - Single and multiple file uploads
  - Form fields with and without files
  - Base64 encoding/decoding with error handling
  - [AsParameters] with records, classes, and service injection
  - Custom binding names via `[FromQuery]`, `[FromForm]`, etc.

## Implementation Details

- Form parameters are detected via `GetFormParameterKind()` enum distinguishing between single files, file collections, and form collections.
- `AddEndpointMember()` centralizes binding inference for both top-level handler parameters and expanded [AsParameters] members.
- `TryExpandAsParameters()` recursively processes surface type members while preventing nested [AsParameters] and respecting `[McpIgnore]` attributes.
- Form data is accumulated in `BoundRequest.FormFields` and `BoundRequest.FormFiles` during argument binding, then encoded appropriately based on content.
- Controller actions with form binding are now supported alongside Minimal APIs.

https://claude.ai/code/session_01XFi8ahUaaKPgz6jXAmpU2c