### PR TITLE
Showcase file uploads and [AsParameters] in the Todo sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,10 +693,12 @@ XML documentation. Two accounts exist, both with the password `password`: `alice
 It is wired up for per-caller tool visibility, so the ordinary authorization attributes are visible at
 work. Connect without a token and `tools/list` returns the `weather_*` tools, because
 `WeatherController` carries `[AllowAnonymous]`, plus `todos_get_priorities`, because that one action
-carries `[AllowAnonymous]` even though its controller carries `[Authorize]`, plus `server_time_now`,
-a Minimal API endpoint published with `.McpTool()` - and all of them can be called. The rest of the
-`todos_*` tools are neither advertised nor callable until you sign in, and `todos_delete` appears
-only for `root`, because it carries `[Authorize(Policy = "AdminOnly")]`.
+carries `[AllowAnonymous]` even though its controller carries `[Authorize]`, plus `server_time_now`
+and `server_time_in_zone`, two Minimal API endpoints published with `.McpTool()` (the latter binds an
+`[AsParameters]` record) - and all of them can be called. The rest of the `todos_*` tools are neither
+advertised nor callable until you sign in - among them `todos_attach`, which uploads a file to a todo
+item as a base64 argument replayed as multipart/form-data - and `todos_delete` appears only for
+`root`, because it carries `[Authorize(Policy = "AdminOnly")]`.
 
 ```bash
 dotnet run --project samples/Nabu.Sample.TodoApi
@@ -717,7 +719,7 @@ docker compose up --build
 A one-shot init container signs in as `alice` and `root` on both samples and writes an Inspector
 config with three connections per sample, each to the same endpoint. For the Todo sample -
 `todo-anonymous`, `todo-alice-user` and `todo-root-admin` - switching between them in the UI shows
-the tool list grow from the 5 anonymous tools to alice's 11 to root's 12 (only root gets
+the tool list grow from the 6 anonymous tools to alice's 13 to root's 14 (only root gets
 `todos_delete`). For the book catalog served through the official SDK - `books-anonymous`,
 `books-alice-user` and `books-root-admin` - the list grows from the 2 search tools to alice's 3
 (`books_add`) to root's 4 (`books_remove`). The Todo API is published on

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -163,7 +163,7 @@ public class TodosController : ControllerBase
       A one-shot init container signs in as <code>alice</code> and <code>root</code> on both samples and
       writes an Inspector config with three connections per sample. Switching between
       <code>todo-anonymous</code>, <code>todo-alice-user</code> and <code>todo-root-admin</code> in the UI
-      shows the tool list grow from 5 anonymous tools to alice's 11 to root's 12. The Todo API is
+      shows the tool list grow from 6 anonymous tools to alice's 13 to root's 14. The Todo API is
       published on <code>http://localhost:5080/mcp</code> and the book catalog (served through the
       official MCP SDK) on <code>http://localhost:5081/books/mcp</code>.
     </p>

--- a/samples/Nabu.Sample.TodoApi/Controllers/TodosController.cs
+++ b/samples/Nabu.Sample.TodoApi/Controllers/TodosController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Nabu.Mcp.AspNetCore;
 using Nabu.Sample.TodoApi.Models;
@@ -150,6 +151,38 @@ namespace Nabu.Sample.TodoApi.Controllers
             });
 
             return item == null ? NotFound(new { message = "No todo item with id " + id + "." }) : (ActionResult<TodoItem>)Ok(item);
+        }
+
+        /// <summary>Attaches a file to a todo item. The sample keeps the file's metadata, not its bytes.</summary>
+        /// <remarks>
+        /// A form-binding action publishes like any other: the <paramref name="file"/> argument is
+        /// advertised to the model as base64 content plus an optional file name and MIME type, and the
+        /// tool call is replayed as a real multipart/form-data request - so this action reads its
+        /// <see cref="IFormFile"/> exactly as it would for a browser upload.
+        /// </remarks>
+        /// <param name="id">Identifier of the item to attach the file to.</param>
+        /// <param name="file">The file to attach.</param>
+        /// <param name="description">Optional description of the attachment.</param>
+        [HttpPost("{id:guid}/attachments")]
+        [McpTool(Idempotent = false)]
+        public ActionResult<TodoAttachment> Attach(
+            Guid id,
+            IFormFile file,
+            [FromForm] [System.ComponentModel.DataAnnotations.StringLength(500)] string? description)
+        {
+            var attachment = new TodoAttachment
+            {
+                Id = Guid.NewGuid(),
+                FileName = file.FileName,
+                ContentType = file.ContentType,
+                SizeBytes = file.Length,
+                Description = description,
+            };
+
+            var item = _repository.Update(Owner, id, existing => existing.Attachments.Add(attachment));
+            return item == null
+                ? NotFound(new { message = "No todo item with id " + id + "." })
+                : (ActionResult<TodoAttachment>)Ok(attachment);
         }
 
         /// <summary>

--- a/samples/Nabu.Sample.TodoApi/Models/TodoModels.cs
+++ b/samples/Nabu.Sample.TodoApi/Models/TodoModels.cs
@@ -43,6 +43,28 @@ namespace Nabu.Sample.TodoApi.Models
 
         /// <summary>When the item was created, in UTC.</summary>
         public DateTimeOffset CreatedAt { get; set; }
+
+        /// <summary>Files attached to the item.</summary>
+        public List<TodoAttachment> Attachments { get; set; } = new List<TodoAttachment>();
+    }
+
+    /// <summary>A file attached to a todo item. The sample stores metadata only, not the content.</summary>
+    public class TodoAttachment
+    {
+        /// <summary>Stable identifier of the attachment.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Name of the uploaded file.</summary>
+        public string FileName { get; set; } = string.Empty;
+
+        /// <summary>MIME type of the uploaded file.</summary>
+        public string ContentType { get; set; } = string.Empty;
+
+        /// <summary>Size of the uploaded content, in bytes.</summary>
+        public long SizeBytes { get; set; }
+
+        /// <summary>Optional description supplied alongside the file.</summary>
+        public string? Description { get; set; }
     }
 
     /// <summary>Payload for creating a todo item.</summary>

--- a/samples/Nabu.Sample.TodoApi/Program.cs
+++ b/samples/Nabu.Sample.TodoApi/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
@@ -85,9 +86,46 @@ app.MapControllers();
 app.MapGet("/api/time", () => new { utcNow = DateTimeOffset.UtcNow })
    .McpTool("server_time_now", "Reports the server's current UTC time.");
 
+// [AsParameters]: the handler gathers its inputs into one record, and each member is published as
+// an individual tool input with the same binding inference it would get as a top-level parameter -
+// here `timeZone` from the route and `format` from the query string.
+app.MapGet("/api/time/{timeZone}", ([AsParameters] TimeInZoneQuery query) =>
+{
+    TimeZoneInfo zone;
+    try
+    {
+        zone = TimeZoneInfo.FindSystemTimeZoneById(query.TimeZone);
+    }
+    catch (TimeZoneNotFoundException)
+    {
+        return Results.NotFound(new { message = "Unknown time zone '" + query.TimeZone + "'." });
+    }
+
+    var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, zone);
+    try
+    {
+        return Results.Ok(new
+        {
+            timeZone = zone.Id,
+            now = now.ToString(query.Format ?? "O", System.Globalization.CultureInfo.InvariantCulture),
+            utcOffset = zone.GetUtcOffset(now).ToString(),
+        });
+    }
+    catch (FormatException)
+    {
+        return Results.BadRequest(new { message = "Invalid format string '" + query.Format + "'." });
+    }
+})
+.McpTool("server_time_in_zone", "Reports the server's current time in a named time zone.");
+
 app.Run();
 
 /// <summary>Exposed so the integration tests can host the application with WebApplicationFactory.</summary>
 public partial class Program
 {
 }
+
+/// <summary>Inputs of the <c>server_time_in_zone</c> tool, gathered with <c>[AsParameters]</c>.</summary>
+/// <param name="TimeZone">IANA or Windows time zone identifier, for example <c>Asia/Yerevan</c>.</param>
+/// <param name="Format">Optional .NET date format string. Defaults to round-trip (<c>O</c>).</param>
+public record TimeInZoneQuery(string TimeZone, string? Format = null);

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/SampleUploadAndAsParametersTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/SampleUploadAndAsParametersTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// The sample application's showcase of the form-upload and <c>[AsParameters]</c> features:
+    /// <c>todos_attach</c> (an <see cref="Microsoft.AspNetCore.Http.IFormFile"/> action on the
+    /// authorized controller) and <c>server_time_in_zone</c> (a Minimal API handler binding an
+    /// <c>[AsParameters]</c> record).
+    /// </summary>
+    [Collection(McpTestCollection.Name)]
+    public class SampleUploadAndAsParametersTests
+    {
+        private readonly McpTestFixture _fixture;
+
+        public SampleUploadAndAsParametersTests(McpTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Todos_attach_is_advertised_with_a_base64_file_argument()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var envelope = await _fixture.RpcAsync("tools/list", token: token);
+            var tools = envelope["result"]!["tools"]!.AsArray();
+
+            var attach = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "todos_attach")!.AsObject();
+            var properties = attach["inputSchema"]!["properties"]!.AsObject();
+
+            Assert.Equal("base64", properties["file"]!["properties"]!["data"]!["contentEncoding"]!.GetValue<string>());
+            Assert.NotNull(properties["description"]);
+
+            var required = attach["inputSchema"]!["required"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray();
+            Assert.Contains("id", required);
+            Assert.Contains("file", required);
+            Assert.DoesNotContain("description", required);
+        }
+
+        [Fact]
+        public async Task Todos_attach_uploads_a_file_to_the_signed_in_users_item()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            var created = McpTestFixture.JsonOf(await _fixture.CallToolAsync(
+                "todos_create",
+                new JsonObject { ["title"] = "Review the audit report" },
+                token)).AsObject();
+
+            var result = await _fixture.CallToolAsync(
+                "todos_attach",
+                new JsonObject
+                {
+                    ["id"] = created["id"]!.GetValue<string>(),
+                    ["description"] = "The report to review",
+                    ["file"] = new JsonObject
+                    {
+                        ["data"] = Convert.ToBase64String(Encoding.UTF8.GetBytes("audit findings")),
+                        ["fileName"] = "audit.txt",
+                        ["contentType"] = "text/plain",
+                    },
+                },
+                token);
+
+            Assert.False(McpTestFixture.IsError(result));
+
+            var attachment = McpTestFixture.JsonOf(result).AsObject();
+            Assert.Equal("audit.txt", attachment["fileName"]!.GetValue<string>());
+            Assert.Equal("text/plain", attachment["contentType"]!.GetValue<string>());
+            Assert.Equal("audit findings".Length, attachment["sizeBytes"]!.GetValue<long>());
+            Assert.Equal("The report to review", attachment["description"]!.GetValue<string>());
+
+            // The attachment is visible on the item afterwards, proving the action really ran.
+            var item = McpTestFixture.JsonOf(await _fixture.CallToolAsync(
+                "todos_get_by_id",
+                new JsonObject { ["id"] = created["id"]!.GetValue<string>() },
+                token)).AsObject();
+
+            Assert.Single(item["attachments"]!.AsArray());
+        }
+
+        [Fact]
+        public async Task Server_time_in_zone_expands_the_AsParameters_record()
+        {
+            var envelope = await _fixture.RpcAsync("tools/list");
+            var tools = envelope["result"]!["tools"]!.AsArray();
+
+            var tool = Assert.Single(tools, t => t!["name"]!.GetValue<string>() == "server_time_in_zone")!.AsObject();
+            var schema = tool["inputSchema"]!.AsObject();
+            var properties = schema["properties"]!.AsObject();
+
+            // The record's members are individual inputs; the record itself never appears.
+            Assert.NotNull(properties["timeZone"]);
+            Assert.NotNull(properties["format"]);
+            Assert.Null(properties["query"]);
+            Assert.Contains("timeZone", schema["required"]!.AsArray().Select(n => n!.GetValue<string>()));
+        }
+
+        [Fact]
+        public async Task Server_time_in_zone_is_callable_anonymously()
+        {
+            var result = await _fixture.CallToolAsync(
+                "server_time_in_zone",
+                new JsonObject { ["timeZone"] = "UTC", ["format"] = "yyyy-MM-dd" });
+
+            Assert.False(McpTestFixture.IsError(result));
+
+            var payload = McpTestFixture.JsonOf(result).AsObject();
+            Assert.Equal("UTC", payload["timeZone"]!.GetValue<string>());
+            Assert.Matches(@"^\d{4}-\d{2}-\d{2}$", payload["now"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public async Task An_unknown_time_zone_is_a_tool_error_the_model_can_read()
+        {
+            var result = await _fixture.CallToolAsync(
+                "server_time_in_zone",
+                new JsonObject { ["timeZone"] = "Mars/Olympus_Mons" });
+
+            Assert.True(McpTestFixture.IsError(result));
+            Assert.Contains("Unknown time zone", McpTestFixture.TextOf(result));
+        }
+    }
+}


### PR DESCRIPTION
todos_attach uploads a file to a todo item through the JWT-authorized pipeline: the IFormFile argument is advertised as base64 content and replayed as multipart/form-data. server_time_in_zone is a Minimal API handler binding an [AsParameters] record, published with its members as individual tool inputs. Tool counts in the docs move to 6/13/14.
