### PR TITLE
Add output shaping to control what tools return to models

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ app.MapGet("/customers/{id}", (int id) => ...)
 - [Minimal APIs](#minimal-apis)
 - [SignalR hubs](#signalr-hubs)
 - [One action, several tools](#one-action-several-tools)
+- [Shaping tool output](#shaping-tool-output)
 - [How arguments are mapped](#how-arguments-are-mapped)
 - [File uploads](#file-uploads)
 - [Schema generation](#schema-generation)
@@ -173,9 +174,11 @@ curl -X POST http://localhost:5000/mcp \
 | `[McpTool]` | controller | Publishes every action on the controller. |
 | `[McpIgnore]` | controller, action, parameter, property | Excludes it. Always wins. |
 | `[McpParameter]` | parameter, property | Overrides the name, description, requiredness or example of one input. |
+| `[McpToolOutput]` | controller, action | Shapes what the tool returns: hides fields or transforms the response with a converter. Repeatable - see [Shaping tool output](#shaping-tool-output). |
 
-For Minimal APIs the same declarations are made with the `.McpTool()` / `.McpIgnore()` endpoint
-conventions (or the same attributes on the handler delegate) - see [Minimal APIs](#minimal-apis).
+For Minimal APIs the same declarations are made with the `.McpTool()` / `.McpIgnore()` /
+`.McpToolOutput()` endpoint conventions (or the same attributes on the handler delegate) - see
+[Minimal APIs](#minimal-apis).
 
 `[McpTool]` also accepts `Name`, `Title`, `Description`, `Enabled`, and the four MCP behaviour hints
 `ReadOnly`, `Destructive`, `Idempotent` and `OpenWorld`. The hints default to the HTTP semantics of the
@@ -401,6 +404,83 @@ Notes:
 - Give every extra variant an explicit `Name`. Variants without one fall back to the generated
   `controller_action` name and collide, and all but the first end up with a `_2`, `_3`, ... suffix.
 - Variants declared on an action replace a controller-wide `[McpTool]` rather than adding to it.
+
+## Shaping tool output
+
+An action's response is often wider than what a model should see: internal identifiers, owner
+fields, audit metadata, payloads sized for a UI rather than a context window. `[McpToolOutput]`
+shapes the JSON a tool returns *after* the pipeline has run - the HTTP API keeps its contract, and
+only MCP clients get the narrowed view.
+
+```csharp
+[HttpGet]
+[McpTool("todos_list")]
+[McpTool("todos_list_compact")]
+[McpToolOutput(Tool = "todos_list_compact",
+    IncludeFields = new[] { "items.id", "items.title", "totalCount" })]
+public ActionResult<TodoPage> List(...) => ...
+```
+
+| Property | Purpose |
+|---|---|
+| `IncludeFields` | Keeps only the listed field paths; every other property is removed. |
+| `ExcludeFields` | Removes the listed field paths. Applied after `IncludeFields`. |
+| `Converter` | An `IMcpToolOutputConverter` type that transforms the (already filtered) JSON. |
+| `Tool` | Scopes the occurrence to one tool of a multi-`[McpTool]` action. Unset applies to all of them. |
+
+Field paths are dot-separated JSON property names, matched case-insensitively, and arrays are
+traversed transparently: `items.owner` removes `owner` from every element of `items`. Both the text
+content and `structuredContent` are shaped. The attribute is repeatable, so each variant of an
+action can publish its own view of the same response; a method-level occurrence overrides a
+controller-level one, and within one level a `Tool`-scoped occurrence wins over an unscoped one.
+
+For transformations that field lists cannot express, name a converter:
+
+```csharp
+[McpTool("todos_get_summary")]
+[McpToolOutput(Tool = "todos_get_summary",
+    ExcludeFields = new[] { "attachments" },
+    Converter = typeof(TodoSummaryOutputConverter))]
+public ActionResult<TodoItem> GetById(Guid id) => ...
+
+public sealed class TodoSummaryOutputConverter : IMcpToolOutputConverter
+{
+    public JsonNode? Convert(McpToolOutputContext context, JsonNode? output)
+    {
+        var item = output!.AsObject();
+        return new JsonObject
+        {
+            ["id"] = item["id"]?.DeepClone(),
+            ["summary"] = item["title"]?.GetValue<string>(),
+        };
+    }
+}
+```
+
+Converters run after the field filters, are resolved from the request's services when registered -
+so they can take dependencies - and are constructed with `ActivatorUtilities` otherwise. Returning
+`null` exposes an empty result.
+
+Minimal APIs use the endpoint convention (or the same attribute on the handler delegate):
+
+```csharp
+app.MapGet("/customers/{id}", (int id) => ...)
+   .McpTool("customers_get")
+   .McpToolOutput(output => output.ExcludeFields = new[] { "ssn" });
+```
+
+Notes:
+
+- Shaping is **fail-closed**. When a successful response cannot be shaped - the body is not valid
+  JSON, or the converter throws - the tool answers an error instead of the raw body, so a filter
+  meant to hide data never leaks it by failing. A converter that names a type which is not a
+  concrete `IMcpToolOutputConverter` keeps the tool from being published at all.
+- Error responses (per `TreatErrorStatusAsToolError`) and empty bodies pass through unshaped: the
+  filters describe the success payload, not the framework's failure text.
+- Only JSON responses can be shaped; a shaped tool answering `text/plain` or XML reports an error.
+- A `Tool` name that matches nothing the action publishes is logged as a warning, exactly like a
+  misspelled parameter name.
+- SignalR hub methods support the same attribute - the shaping applies to the hub result JSON.
 
 ## How arguments are mapped
 

--- a/docs/attributes-and-tools.html
+++ b/docs/attributes-and-tools.html
@@ -56,8 +56,8 @@
 <main>
   <article class="doc">
     <h1>Attributes &amp; tools</h1>
-    <p class="lede">Four attributes cover the whole surface: publish, exclude, and shape individual inputs —
-    plus the ability to publish one action as several differently shaped tools.</p>
+    <p class="lede">A handful of attributes cover the whole surface: publish, exclude, shape individual inputs,
+    and shape what a tool returns — plus the ability to publish one action as several differently shaped tools.</p>
 
     <h2 id="attributes">The attribute surface</h2>
     <table>
@@ -67,12 +67,13 @@
         <tr><td><code>[McpTool]</code></td><td>controller</td><td>Publishes every action on the controller.</td></tr>
         <tr><td><code>[McpIgnore]</code></td><td>controller, action, parameter, property</td><td>Excludes it. Always wins.</td></tr>
         <tr><td><code>[McpParameter]</code></td><td>parameter, property</td><td>Overrides the name, description, requiredness or example of one input.</td></tr>
+        <tr><td><code>[McpToolOutput]</code></td><td>controller, action</td><td>Shapes what the tool returns: hides fields or transforms the response with a converter. Repeatable — see <a href="#shaping-tool-output">Shaping tool output</a>.</td></tr>
       </tbody>
     </table>
     <p>
       For Minimal APIs the same declarations are made with the <code>.McpTool()</code> /
-      <code>.McpIgnore()</code> endpoint conventions (or the same attributes on the handler delegate) —
-      see <a href="minimal-apis.html">Minimal APIs</a>.
+      <code>.McpIgnore()</code> / <code>.McpToolOutput()</code> endpoint conventions (or the same
+      attributes on the handler delegate) — see <a href="minimal-apis.html">Minimal APIs</a>.
     </p>
     <p>
       <code>[McpTool]</code> also accepts <code>Name</code>, <code>Title</code>, <code>Description</code>,
@@ -153,6 +154,75 @@ public ActionResult&lt;IEnumerable&lt;Forecast&gt;&gt; GetForecast(string city, 
         <code>_2</code>, <code>_3</code>, ... suffix.</li>
       <li>Variants declared on an action replace a controller-wide <code>[McpTool]</code> rather than
         adding to it.</li>
+    </ul>
+
+    <h2 id="shaping-tool-output">Shaping tool output</h2>
+    <p>
+      An action's response is often wider than what a model should see: internal identifiers, owner
+      fields, audit metadata, payloads sized for a UI rather than a context window.
+      <code>[McpToolOutput]</code> shapes the JSON a tool returns <em>after</em> the pipeline has run —
+      the HTTP API keeps its contract, and only MCP clients get the narrowed view.
+    </p>
+    <pre><code>[HttpGet]
+[McpTool("todos_list")]
+[McpTool("todos_list_compact")]
+[McpToolOutput(Tool = "todos_list_compact",
+    IncludeFields = new[] { "items.id", "items.title", "totalCount" })]
+public ActionResult&lt;TodoPage&gt; List(...) =&gt; ...</code></pre>
+    <table>
+      <thead><tr><th>Property</th><th>Effect</th></tr></thead>
+      <tbody>
+        <tr><td><code>IncludeFields</code></td><td>Keeps only the listed field paths; every other property is removed.</td></tr>
+        <tr><td><code>ExcludeFields</code></td><td>Removes the listed field paths. Applied after <code>IncludeFields</code>.</td></tr>
+        <tr><td><code>Converter</code></td><td>An <code>IMcpToolOutputConverter</code> type that transforms the (already filtered) JSON.</td></tr>
+        <tr><td><code>Tool</code></td><td>Scopes the occurrence to one tool of a multi-<code>[McpTool]</code> action. Unset applies to all of them.</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Field paths are dot-separated JSON property names, matched case-insensitively, and arrays are
+      traversed transparently: <code>items.owner</code> removes <code>owner</code> from every element of
+      <code>items</code>. Both the text content and <code>structuredContent</code> are shaped. The
+      attribute is repeatable, so each variant of an action can publish its own view of the same
+      response; a method-level occurrence overrides a controller-level one, and within one level a
+      <code>Tool</code>-scoped occurrence wins over an unscoped one.
+    </p>
+    <p>For transformations that field lists cannot express, name a converter:</p>
+    <pre><code>[McpTool("todos_get_summary")]
+[McpToolOutput(Tool = "todos_get_summary",
+    ExcludeFields = new[] { "attachments" },
+    Converter = typeof(TodoSummaryOutputConverter))]
+public ActionResult&lt;TodoItem&gt; GetById(Guid id) =&gt; ...
+
+public sealed class TodoSummaryOutputConverter : IMcpToolOutputConverter
+{
+    public JsonNode? Convert(McpToolOutputContext context, JsonNode? output)
+    {
+        var item = output!.AsObject();
+        return new JsonObject
+        {
+            ["id"] = item["id"]?.DeepClone(),
+            ["summary"] = item["title"]?.GetValue&lt;string&gt;(),
+        };
+    }
+}</code></pre>
+    <p>
+      Converters run after the field filters, are resolved from the request's services when registered —
+      so they can take dependencies — and are constructed with <code>ActivatorUtilities</code> otherwise.
+      Returning <code>null</code> exposes an empty result.
+    </p>
+    <h3 id="output-shaping-notes">Notes</h3>
+    <ul>
+      <li>Shaping is <strong>fail-closed</strong>. When a successful response cannot be shaped — the body
+        is not valid JSON, or the converter throws — the tool answers an error instead of the raw body,
+        so a filter meant to hide data never leaks it by failing. A converter that names a type which is
+        not a concrete <code>IMcpToolOutputConverter</code> keeps the tool from being published at all.</li>
+      <li>Error responses (per <code>TreatErrorStatusAsToolError</code>) and empty bodies pass through
+        unshaped: the filters describe the success payload, not the framework's failure text.</li>
+      <li>Only JSON responses can be shaped; a shaped tool answering <code>text/plain</code> or XML
+        reports an error.</li>
+      <li>A <code>Tool</code> name that matches nothing the action publishes is logged as a warning,
+        exactly like a misspelled parameter name.</li>
+      <li>SignalR hub methods support the same attribute — the shaping applies to the hub result JSON.</li>
     </ul>
 
     <h2 id="argument-mapping">How arguments are mapped</h2>

--- a/docs/minimal-apis.html
+++ b/docs/minimal-apis.html
@@ -102,6 +102,10 @@ app.MapPost("/orders", (CreateOrder order) =&gt; ...)
         <a href="attributes-and-tools.html#one-action-several-tools">several tools over one endpoint</a>.</li>
       <li>An attribute on the handler itself is equivalent to the extension:
         <code>app.MapGet("/ping", [McpTool("ping")] () =&gt; ...)</code>.</li>
+      <li><code>.McpToolOutput(output =&gt; { ... })</code> (or <code>[McpToolOutput]</code> on the
+        handler) <a href="attributes-and-tools.html#shaping-tool-output">shapes what the endpoint's
+        tools return</a> — field include/exclude paths and output converters, scoped per tool with its
+        <code>Tool</code> property.</li>
       <li><code>.McpIgnore()</code> (or <code>[McpIgnore]</code> on the handler) keeps an endpoint out of
         discovery, which matters when <code>ExposeAllActions</code> is on — that option publishes every
         delegate route handler just as it publishes every controller action, and

--- a/samples/Nabu.Sample.TodoApi/Controllers/TodosController.cs
+++ b/samples/Nabu.Sample.TodoApi/Controllers/TodosController.cs
@@ -56,6 +56,13 @@ namespace Nabu.Sample.TodoApi.Controllers
         [HttpGet]
         [McpTool]
         [McpTool(
+            "todos_list_compact",
+            Title = "List todos (compact)",
+            Description = "Lists the signed-in user's todo items with only their identifying fields.")]
+        [McpToolOutput(
+            Tool = "todos_list_compact",
+            IncludeFields = new[] { "items.id", "items.title", "items.isCompleted", "totalCount" })]
+        [McpTool(
             "todos_list_open",
             Title = "List open todos",
             Description = "Lists the todo items that are still open. Completed items are never returned.",
@@ -90,6 +97,14 @@ namespace Nabu.Sample.TodoApi.Controllers
         /// <param name="id">Identifier of the item.</param>
         [HttpGet("{id:guid}")]
         [McpTool]
+        [McpTool(
+            "todos_get_summary",
+            Title = "Summarize a todo",
+            Description = "Returns a one-line summary of a todo item instead of the full record.")]
+        [McpToolOutput(
+            Tool = "todos_get_summary",
+            ExcludeFields = new[] { "attachments" },
+            Converter = typeof(TodoSummaryOutputConverter))]
         public ActionResult<TodoItem> GetById(Guid id)
         {
             var item = _repository.Find(Owner, id);

--- a/samples/Nabu.Sample.TodoApi/Program.cs
+++ b/samples/Nabu.Sample.TodoApi/Program.cs
@@ -116,7 +116,16 @@ app.MapGet("/api/time/{timeZone}", ([AsParameters] TimeInZoneQuery query) =>
         return Results.BadRequest(new { message = "Invalid format string '" + query.Format + "'." });
     }
 })
-.McpTool("server_time_in_zone", "Reports the server's current time in a named time zone.");
+.McpTool("server_time_in_zone", "Reports the server's current time in a named time zone.")
+
+// Output shaping works for Minimal APIs too: this second variant answers the same handler's
+// response without the utcOffset field. Scoping with Tool leaves server_time_in_zone untouched.
+.McpTool("server_time_in_zone_brief", "Reports the server's current time in a named time zone, without the UTC offset.")
+.McpToolOutput(output =>
+{
+    output.Tool = "server_time_in_zone_brief";
+    output.ExcludeFields = new[] { "utcOffset" };
+});
 
 app.Run();
 

--- a/samples/Nabu.Sample.TodoApi/Services/TodoSummaryOutputConverter.cs
+++ b/samples/Nabu.Sample.TodoApi/Services/TodoSummaryOutputConverter.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Nodes;
+using Nabu.Mcp.AspNetCore.Execution;
+
+namespace Nabu.Sample.TodoApi.Services
+{
+    /// <summary>
+    /// Output converter behind the <c>todos_get_summary</c> tool: collapses the full
+    /// <see cref="Models.TodoItem"/> JSON into a one-line summary. It runs after the attribute's
+    /// field filters, so the <c>attachments</c> list is already gone by the time it looks at the
+    /// item. Converters are resolved from the request's services when registered - this one is not,
+    /// so Nabu constructs it on demand.
+    /// </summary>
+    public sealed class TodoSummaryOutputConverter : IMcpToolOutputConverter
+    {
+        public JsonNode? Convert(McpToolOutputContext context, JsonNode? output)
+        {
+            var item = output as JsonObject;
+            if (item == null)
+            {
+                return output;
+            }
+
+            var title = item["title"]?.GetValue<string>() ?? "(untitled)";
+            var completed = item["isCompleted"]?.GetValue<bool>() ?? false;
+
+            return new JsonObject
+            {
+                ["id"] = item["id"]?.DeepClone(),
+                ["summary"] = (completed ? "[done] " : "[open] ") + title,
+                ["dueOn"] = item["dueOn"]?.DeepClone(),
+            };
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore.SignalR/Discovery/SignalRHubToolSource.cs
+++ b/src/Nabu.Mcp.AspNetCore.SignalR/Discovery/SignalRHubToolSource.cs
@@ -125,6 +125,7 @@ namespace Nabu.Mcp.AspNetCore.SignalR.Discovery
             }
 
             var classAttributes = hubType.GetCustomAttributes<McpToolAttribute>(inherit: true).ToList();
+            var classOutputs = hubType.GetCustomAttributes<McpToolOutputAttribute>(inherit: true).ToList();
             var classAuthorizeData = hubType.GetCustomAttributes(inherit: true).OfType<IAuthorizeData>().ToList();
             var classAllowsAnonymous = hubType.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any();
             var hubName = TrimHubSuffix(hubType.Name);
@@ -173,6 +174,9 @@ namespace Nabu.Mcp.AspNetCore.SignalR.Discovery
                     continue;
                 }
 
+                var methodOutputs = method.GetCustomAttributes<McpToolOutputAttribute>(inherit: true).ToList();
+                var matchedOutputs = new HashSet<McpToolOutputAttribute>();
+
                 foreach (var variant in variants)
                 {
                     if (variant != null && !variant.Enabled)
@@ -188,12 +192,15 @@ namespace Nabu.Mcp.AspNetCore.SignalR.Discovery
                     var tool = CreateTool(
                         hubType, hubName, route, method, parameters,
                         useVariantIdentity ? variant : null,
-                        classAuthorizeData, classAllowsAnonymous, usedNames);
+                        classAuthorizeData, classAllowsAnonymous, usedNames,
+                        methodOutputs, classOutputs, matchedOutputs);
                     if (tool != null)
                     {
                         results.Add(tool);
                     }
                 }
+
+                McpToolOutputResolver.WarnUnmatched(methodOutputs, matchedOutputs, hubType.Name + "." + method.Name, _logger);
             }
 
             return results;
@@ -208,7 +215,10 @@ namespace Nabu.Mcp.AspNetCore.SignalR.Discovery
             McpToolAttribute? attribute,
             IReadOnlyList<IAuthorizeData> classAuthorizeData,
             bool classAllowsAnonymous,
-            ISet<string> usedNames)
+            ISet<string> usedNames,
+            IReadOnlyList<McpToolOutputAttribute> methodOutputs,
+            IReadOnlyList<McpToolOutputAttribute> classOutputs,
+            ISet<McpToolOutputAttribute> matchedOutputs)
         {
             var display = hubType.Name + "." + method.Name;
 
@@ -276,6 +286,13 @@ namespace Nabu.Mcp.AspNetCore.SignalR.Discovery
 
             name = ReserveName(McpToolRegistry.Sanitize(name!), usedNames, display);
 
+            McpToolOutputDescriptor? output;
+            if (!McpToolOutputResolver.TrySelect(
+                    methodOutputs, classOutputs, name, attribute?.Name, display, _logger, matchedOutputs, out output))
+            {
+                return null;
+            }
+
             var annotations = new McpToolAnnotations
             {
                 Title = attribute?.Title ?? McpToolRegistry.Humanize(method.Name),
@@ -293,6 +310,7 @@ namespace Nabu.Mcp.AspNetCore.SignalR.Discovery
                 InvokerType = typeof(SignalRHubToolInvoker),
                 Constants = constants,
                 Authorization = BuildAuthorization(method, classAuthorizeData, classAllowsAnonymous),
+                Output = output,
             };
 
             MetadataTable.Add(descriptor, new SignalRHubToolMetadata(

--- a/src/Nabu.Mcp.AspNetCore/Attributes/McpToolOutputAttribute.cs
+++ b/src/Nabu.Mcp.AspNetCore/Attributes/McpToolOutputAttribute.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace Nabu.Mcp.AspNetCore
+{
+    /// <summary>
+    /// Controls what a tool returns to the model. The underlying action keeps producing its full
+    /// response - this attribute shapes the JSON body <em>after</em> the pipeline has run and before
+    /// it becomes tool content, so fields can be hidden from MCP clients without touching the API
+    /// contract that HTTP callers see.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Field selection uses dot-separated paths matched case-insensitively against JSON property
+    /// names (<c>"items.owner"</c>). Arrays are traversed transparently: a segment that lands on an
+    /// array applies to every element. <see cref="IncludeFields"/> keeps only the listed paths,
+    /// <see cref="ExcludeFields"/> removes the listed paths, and when both are set the include list
+    /// is applied first. <see cref="Converter"/> then receives the (already filtered) JSON and may
+    /// reduce, transform or replace it entirely.
+    /// </para>
+    /// <para>
+    /// Shaping is deliberately fail-closed: when a successful response cannot be shaped - the body
+    /// is not valid JSON, or the converter throws - the tool answers an error instead of exposing
+    /// the raw response, so a filter meant to hide data never leaks it by failing.
+    /// </para>
+    /// <para>
+    /// The attribute may be applied several times. An occurrence with <see cref="Tool"/> set applies
+    /// only to the tool of that name, which is how each variant of a multi-<see cref="McpToolAttribute"/>
+    /// action gets its own output shape; an occurrence without <see cref="Tool"/> applies to every
+    /// tool the action publishes. A method-level occurrence takes precedence over a controller-level
+    /// one, and within one level a <see cref="Tool"/>-scoped occurrence wins over an unscoped one.
+    /// </para>
+    /// <para>
+    /// Error responses (as decided by <see cref="NabuMcpOptions.TreatErrorStatusAsToolError"/>) and
+    /// empty bodies are not shaped: filters describe the success payload, not the failure text.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [HttpGet]
+    /// [McpTool("todos_list")]
+    /// [McpTool("todos_list_compact")]
+    /// [McpToolOutput(Tool = "todos_list_compact",
+    ///     IncludeFields = new[] { "items.id", "items.title", "totalCount" })]
+    /// [McpToolOutput(Tool = "todos_list",
+    ///     ExcludeFields = new[] { "items.owner" })]
+    /// public ActionResult&lt;TodoPage&gt; List(...)
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public sealed class McpToolOutputAttribute : Attribute
+    {
+        public McpToolOutputAttribute()
+        {
+        }
+
+        /// <param name="converter">
+        /// A type implementing <see cref="Execution.IMcpToolOutputConverter"/> - see <see cref="Converter"/>.
+        /// </param>
+        public McpToolOutputAttribute(Type converter)
+        {
+            Converter = converter;
+        }
+
+        /// <summary>
+        /// Name of the tool this occurrence applies to. <c>null</c> - the default - applies it to
+        /// every tool published by the action. Matches the advertised tool name or the name declared
+        /// on the corresponding <see cref="McpToolAttribute"/>, case-insensitively.
+        /// </summary>
+        public string? Tool { get; set; }
+
+        /// <summary>
+        /// Restricts the response to this set of fields; every property not on a listed path is
+        /// removed. Paths are dot-separated (<c>"items.id"</c>) and traverse arrays transparently.
+        /// <c>null</c> or empty means "keep every field", which is the default.
+        /// </summary>
+        public string[]? IncludeFields { get; set; }
+
+        /// <summary>
+        /// Removes these fields from the response. Applied after <see cref="IncludeFields"/>, so a
+        /// field can be carved out of an included subtree.
+        /// </summary>
+        public string[]? ExcludeFields { get; set; }
+
+        /// <summary>
+        /// A type implementing <see cref="Execution.IMcpToolOutputConverter"/> that transforms the
+        /// response after the field filters have run. Resolved from the request's services when
+        /// registered, otherwise constructed with <c>ActivatorUtilities</c>, so it may take
+        /// dependencies. It receives the parsed JSON and returns the JSON to expose - or <c>null</c>
+        /// to expose nothing.
+        /// </summary>
+        public Type? Converter { get; set; }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpEndpointConventionBuilderExtensions.cs
+++ b/src/Nabu.Mcp.AspNetCore/DependencyInjection/NabuMcpEndpointConventionBuilderExtensions.cs
@@ -85,6 +85,50 @@ namespace Nabu.Mcp.AspNetCore
         }
 
         /// <summary>
+        /// Shapes what the endpoint's tools return to the model, giving access to the full
+        /// <see cref="McpToolOutputAttribute"/> surface - field include/exclude paths and an output
+        /// converter. Scope an occurrence to one tool of a multi-<c>McpTool</c> endpoint with
+        /// <see cref="McpToolOutputAttribute.Tool"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// app.MapGet("/customers/{id}", (int id) => ...)
+        ///    .McpTool("customers_get")
+        ///    .McpToolOutput(output => output.ExcludeFields = new[] { "ssn", "addresses.street" });
+        /// </code>
+        /// </example>
+        public static TBuilder McpToolOutput<TBuilder>(this TBuilder builder, Action<McpToolOutputAttribute> configure)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var output = new McpToolOutputAttribute();
+            configure(output);
+            return builder.McpToolOutput(output);
+        }
+
+        /// <summary>Shapes what the endpoint's tools return, as described by <paramref name="output"/>.</summary>
+        public static TBuilder McpToolOutput<TBuilder>(this TBuilder builder, McpToolOutputAttribute output)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            builder.Add(endpoint => endpoint.Metadata.Add(output));
+            return builder;
+        }
+
+        /// <summary>
         /// Keeps the endpoint out of MCP discovery. Relevant with
         /// <see cref="NabuMcpOptions.ExposeAllActions"/>, which otherwise publishes every route handler.
         /// </summary>

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolDescriptor.cs
@@ -229,6 +229,13 @@ namespace Nabu.Mcp.AspNetCore.Discovery
         /// </summary>
         public Type? InvokerType { get; set; }
 
+        /// <summary>
+        /// How the response body is shaped before it becomes tool content - field include/exclude
+        /// paths and an optional converter, populated from <see cref="McpToolOutputAttribute"/>.
+        /// <c>null</c> - the default - exposes the response as-is.
+        /// </summary>
+        public McpToolOutputDescriptor? Output { get; set; }
+
         public override string ToString() =>
             HttpMethod.Length == 0 ? Name : Name + " (" + HttpMethod + " /" + RouteTemplate + ")";
     }

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolOutputDescriptor.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolOutputDescriptor.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace Nabu.Mcp.AspNetCore.Discovery
+{
+    /// <summary>
+    /// How a tool's response body is shaped before it becomes tool content: the field paths to keep
+    /// or drop, and an optional converter type. Resolved from <see cref="McpToolOutputAttribute"/>
+    /// during discovery; a tool without one (<see cref="McpToolDescriptor.Output"/> is <c>null</c>)
+    /// exposes its response as-is.
+    /// </summary>
+    public sealed class McpToolOutputDescriptor
+    {
+        public McpToolOutputDescriptor(
+            IReadOnlyList<string>? includeFields,
+            IReadOnlyList<string>? excludeFields,
+            Type? converterType)
+        {
+            IncludeFields = includeFields != null && includeFields.Count > 0 ? includeFields : null;
+            ExcludeFields = excludeFields != null && excludeFields.Count > 0 ? excludeFields : null;
+            ConverterType = converterType;
+        }
+
+        /// <summary>
+        /// Dot-separated field paths to keep; everything else is removed. <c>null</c> keeps every field.
+        /// </summary>
+        public IReadOnlyList<string>? IncludeFields { get; }
+
+        /// <summary>Dot-separated field paths removed after <see cref="IncludeFields"/> was applied.</summary>
+        public IReadOnlyList<string>? ExcludeFields { get; }
+
+        /// <summary>
+        /// The <see cref="Execution.IMcpToolOutputConverter"/> implementation run after the field
+        /// filters, or <c>null</c> for filter-only shaping.
+        /// </summary>
+        public Type? ConverterType { get; }
+
+        /// <summary>True when this descriptor changes nothing - no filters and no converter.</summary>
+        public bool IsEmpty
+        {
+            get { return IncludeFields == null && ExcludeFields == null && ConverterType == null; }
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolOutputResolver.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolOutputResolver.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Nabu.Mcp.AspNetCore.Execution;
+
+namespace Nabu.Mcp.AspNetCore.Discovery
+{
+    /// <summary>
+    /// Turns the <see cref="McpToolOutputAttribute"/> occurrences found on an action, endpoint or hub
+    /// method into the <see cref="McpToolOutputDescriptor"/> for one published tool. Shared by every
+    /// discovery path so the precedence rules stay identical: method level beats class level, and a
+    /// <see cref="McpToolOutputAttribute.Tool"/>-scoped occurrence beats an unscoped one.
+    /// </summary>
+    internal static class McpToolOutputResolver
+    {
+        internal static readonly McpToolOutputAttribute[] None = new McpToolOutputAttribute[0];
+
+        /// <summary>
+        /// Selects the occurrence that applies to the tool named <paramref name="resolvedName"/>
+        /// (declared as <paramref name="declaredName"/> on its <see cref="McpToolAttribute"/>, when
+        /// one was) and validates it. Returns <c>false</c> when the configuration is invalid - the
+        /// converter type does not implement <see cref="IMcpToolOutputConverter"/> - in which case
+        /// the tool must not be published: an output filter exists to hide data, so a broken one
+        /// fails closed rather than publishing the tool unshaped. <paramref name="matched"/> records
+        /// which occurrences applied somewhere, for the unmatched-name warning.
+        /// </summary>
+        internal static bool TrySelect(
+            IReadOnlyList<McpToolOutputAttribute> methodLevel,
+            IReadOnlyList<McpToolOutputAttribute> classLevel,
+            string resolvedName,
+            string? declaredName,
+            string display,
+            ILogger logger,
+            ISet<McpToolOutputAttribute>? matched,
+            out McpToolOutputDescriptor? output)
+        {
+            output = null;
+
+            var attribute = Pick(methodLevel, resolvedName, declaredName, scoped: true, display, logger)
+                            ?? Pick(methodLevel, resolvedName, declaredName, scoped: false, display, logger)
+                            ?? Pick(classLevel, resolvedName, declaredName, scoped: true, display, logger)
+                            ?? Pick(classLevel, resolvedName, declaredName, scoped: false, display, logger);
+
+            if (attribute == null)
+            {
+                return true;
+            }
+
+            matched?.Add(attribute);
+            return TryCreate(attribute, resolvedName, display, logger, out output);
+        }
+
+        /// <summary>
+        /// A misspelled <see cref="McpToolOutputAttribute.Tool"/> would otherwise fail silently - the
+        /// tool would simply publish unshaped - so every scoped occurrence that applied to nothing is
+        /// reported. Only method-level occurrences are checked: a class-level one may legitimately
+        /// target another member of the same class.
+        /// </summary>
+        internal static void WarnUnmatched(
+            IReadOnlyList<McpToolOutputAttribute> methodLevel,
+            ISet<McpToolOutputAttribute> matched,
+            string display,
+            ILogger logger)
+        {
+            foreach (var attribute in methodLevel)
+            {
+                if (!string.IsNullOrEmpty(attribute.Tool) && !matched.Contains(attribute))
+                {
+                    logger.LogWarning(
+                        "Nabu MCP ignored an [McpToolOutput] occurrence on {Endpoint}: it targets Tool = '{Tool}', " +
+                        "but no tool of that name is published there.",
+                        display,
+                        attribute.Tool);
+                }
+            }
+        }
+
+        private static McpToolOutputAttribute? Pick(
+            IReadOnlyList<McpToolOutputAttribute> attributes,
+            string resolvedName,
+            string? declaredName,
+            bool scoped,
+            string display,
+            ILogger logger)
+        {
+            McpToolOutputAttribute? found = null;
+
+            foreach (var attribute in attributes)
+            {
+                var isScoped = !string.IsNullOrEmpty(attribute.Tool);
+                if (isScoped != scoped)
+                {
+                    continue;
+                }
+
+                if (scoped &&
+                    !string.Equals(attribute.Tool, resolvedName, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(attribute.Tool, declaredName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (found != null)
+                {
+                    logger.LogWarning(
+                        "Nabu MCP found more than one applicable [McpToolOutput] occurrence for tool '{Tool}' on {Endpoint}; " +
+                        "only the first is applied. Scope each occurrence with its Tool property.",
+                        resolvedName,
+                        display);
+                    break;
+                }
+
+                found = attribute;
+            }
+
+            return found;
+        }
+
+        private static bool TryCreate(
+            McpToolOutputAttribute attribute,
+            string resolvedName,
+            string display,
+            ILogger logger,
+            out McpToolOutputDescriptor? output)
+        {
+            output = null;
+
+            var converter = attribute.Converter;
+            if (converter != null &&
+                (!typeof(IMcpToolOutputConverter).IsAssignableFrom(converter) || converter.IsAbstract))
+            {
+                logger.LogWarning(
+                    "Nabu MCP did not publish tool '{Tool}' on {Endpoint}: its [McpToolOutput] names {Converter} " +
+                    "as the output converter, but that type is not a concrete IMcpToolOutputConverter.",
+                    resolvedName,
+                    display,
+                    converter.FullName);
+                return false;
+            }
+
+            var include = NormalizePaths(attribute.IncludeFields, display, logger);
+            var exclude = NormalizePaths(attribute.ExcludeFields, display, logger);
+
+            var descriptor = new McpToolOutputDescriptor(include, exclude, converter);
+            if (descriptor.IsEmpty)
+            {
+                logger.LogWarning(
+                    "Nabu MCP ignored an [McpToolOutput] occurrence on {Endpoint}: it lists no fields and names no converter.",
+                    display);
+                return true;
+            }
+
+            output = descriptor;
+            return true;
+        }
+
+        private static IReadOnlyList<string>? NormalizePaths(string[]? paths, string display, ILogger logger)
+        {
+            if (paths == null || paths.Length == 0)
+            {
+                return null;
+            }
+
+            var normalized = new List<string>(paths.Length);
+            foreach (var path in paths)
+            {
+                var clean = NormalizePath(path);
+                if (clean == null)
+                {
+                    logger.LogWarning(
+                        "Nabu MCP ignored the [McpToolOutput] field path '{Path}' on {Endpoint}: " +
+                        "paths are dot-separated property names with no empty segments.",
+                        path,
+                        display);
+                    continue;
+                }
+
+                normalized.Add(clean);
+            }
+
+            return normalized.Count == 0 ? null : normalized;
+        }
+
+        /// <summary>Trims each segment, or returns <c>null</c> for a path with an empty segment.</summary>
+        private static string? NormalizePath(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            var segments = path!.Split('.');
+            for (var i = 0; i < segments.Length; i++)
+            {
+                segments[i] = segments[i].Trim();
+                if (segments[i].Length == 0)
+                {
+                    return null;
+                }
+            }
+
+            return string.Join(".", segments);
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.Endpoints.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.Endpoints.cs
@@ -199,6 +199,9 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             var fallbackTitle = httpMethod + " /" + routeTemplate;
             var results = new List<McpToolDescriptor>(variants.Count);
 
+            var outputs = new List<McpToolOutputAttribute>(metadata.GetOrderedMetadata<McpToolOutputAttribute>());
+            var matchedOutputs = new HashSet<McpToolOutputAttribute>();
+
             foreach (var attribute in variants)
             {
                 if (attribute != null && !attribute.Enabled)
@@ -220,14 +223,24 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 var inputSchema = BuildInputSchema(parameters);
                 var annotations = BuildAnnotations(attribute, attribute, httpMethod, fallbackTitle);
 
+                McpToolOutputDescriptor? output;
+                if (!McpToolOutputResolver.TrySelect(
+                        outputs, McpToolOutputResolver.None, name, attribute?.Name, display, _logger, matchedOutputs, out output))
+                {
+                    continue;
+                }
+
                 results.Add(new McpToolDescriptor(name, httpMethod, routeTemplate, parameters, inputSchema, annotations)
                 {
                     Description = ResolveEndpointDescription(attribute, method, httpMethod, routeTemplate),
                     Constants = constants,
                     Authorization = authorization,
                     Endpoint = endpoint,
+                    Output = output,
                 });
             }
+
+            McpToolOutputResolver.WarnUnmatched(outputs, matchedOutputs, display, _logger);
 
             return results;
         }

--- a/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
+++ b/src/Nabu.Mcp.AspNetCore/Discovery/McpToolRegistry.cs
@@ -265,6 +265,10 @@ namespace Nabu.Mcp.AspNetCore.Discovery
             var controllerAttributes = controllerType.GetCustomAttributes<McpToolAttribute>(inherit: true).ToList();
             var controllerAttribute = controllerAttributes.Count > 0 ? controllerAttributes[0] : null;
 
+            var methodOutputs = method.GetCustomAttributes<McpToolOutputAttribute>(inherit: true).ToList();
+            var controllerOutputs = controllerType.GetCustomAttributes<McpToolOutputAttribute>(inherit: true).ToList();
+            var matchedOutputs = new HashSet<McpToolOutputAttribute>();
+
             // A controller-wide [McpTool] is a default for the actions that carry none of their own; an
             // action that declares its own variants replaces it rather than adding to it.
             var isMethodLevel = methodAttributes.Count > 0;
@@ -338,14 +342,24 @@ namespace Nabu.Mcp.AspNetCore.Discovery
                 var annotations = BuildAnnotations(attribute, methodAttribute, httpMethod, Humanize(action.ActionName));
                 var name = ResolveName(action, methodAttribute, httpMethod, routeTemplate, usedNames);
 
+                McpToolOutputDescriptor? output;
+                if (!McpToolOutputResolver.TrySelect(
+                        methodOutputs, controllerOutputs, name, methodAttribute?.Name, display, _logger, matchedOutputs, out output))
+                {
+                    continue;
+                }
+
                 results.Add(new McpToolDescriptor(name, httpMethod, routeTemplate, action, parameters, inputSchema, annotations)
                 {
                     Description = ResolveDescription(action, methodAttribute, controllerAttribute, httpMethod, routeTemplate),
                     ConstantRouteValues = new Dictionary<string, string?>(action.RouteValues, StringComparer.OrdinalIgnoreCase),
                     Constants = constants,
                     Authorization = ResolveAuthorization(action),
+                    Output = output,
                 });
             }
+
+            McpToolOutputResolver.WarnUnmatched(methodOutputs, matchedOutputs, display, _logger);
 
             return results;
         }

--- a/src/Nabu.Mcp.AspNetCore/Execution/IMcpToolOutputConverter.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/IMcpToolOutputConverter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Nabu.Mcp.AspNetCore.Discovery;
+
+namespace Nabu.Mcp.AspNetCore.Execution
+{
+    /// <summary>
+    /// Transforms the JSON a tool is about to return, named by
+    /// <see cref="McpToolOutputAttribute.Converter"/>. Runs after the attribute's field filters, so
+    /// it receives the already-narrowed payload. Implementations are resolved from the request's
+    /// services when registered - so they may take dependencies - and constructed with
+    /// <c>ActivatorUtilities</c> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// A converter only ever runs on successful, non-empty responses. Shaping is fail-closed: an
+    /// exception thrown here turns the tool result into an error rather than exposing the
+    /// untransformed response, so a converter meant to hide data never leaks it by failing.
+    /// </remarks>
+    public interface IMcpToolOutputConverter
+    {
+        /// <summary>
+        /// Returns the JSON to expose to the MCP client in place of <paramref name="output"/>.
+        /// The node may be mutated and returned, or replaced entirely; returning <c>null</c>
+        /// exposes an empty result.
+        /// </summary>
+        /// <param name="context">The tool, the raw HTTP outcome, and the current request services.</param>
+        /// <param name="output">
+        /// The parsed response body after <see cref="McpToolOutputAttribute.IncludeFields"/> and
+        /// <see cref="McpToolOutputAttribute.ExcludeFields"/> were applied. <c>null</c> when the
+        /// body was the JSON literal <c>null</c>.
+        /// </param>
+        JsonNode? Convert(McpToolOutputContext context, JsonNode? output);
+    }
+
+    /// <summary>What an <see cref="IMcpToolOutputConverter"/> gets to look at while transforming.</summary>
+    public sealed class McpToolOutputContext
+    {
+        public McpToolOutputContext(McpToolDescriptor tool, McpToolInvocationResult result, HttpContext httpContext)
+        {
+            Tool = tool ?? throw new ArgumentNullException(nameof(tool));
+            Result = result ?? throw new ArgumentNullException(nameof(result));
+            HttpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+        }
+
+        /// <summary>The tool being answered.</summary>
+        public McpToolDescriptor Tool { get; }
+
+        /// <summary>The raw HTTP outcome of the replayed request - status code, headers, body.</summary>
+        public McpToolInvocationResult Result { get; }
+
+        /// <summary>The MCP request's <see cref="Microsoft.AspNetCore.Http.HttpContext"/>.</summary>
+        public HttpContext HttpContext { get; }
+
+        /// <summary>The current request's service provider.</summary>
+        public IServiceProvider Services
+        {
+            get { return HttpContext.RequestServices; }
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Execution/McpToolOutputShaper.cs
+++ b/src/Nabu.Mcp.AspNetCore/Execution/McpToolOutputShaper.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nabu.Mcp.AspNetCore.Discovery;
+
+namespace Nabu.Mcp.AspNetCore.Execution
+{
+    /// <summary>
+    /// Applies a tool's <see cref="McpToolOutputDescriptor"/> to the response body: parses the JSON,
+    /// prunes it to the include/exclude field paths, and runs the converter. Shaping either succeeds
+    /// or reports a reason - it never hands back the unshaped body, because the caller treats a
+    /// failure as a tool error (fail-closed) rather than exposing what the shaping meant to hide.
+    /// </summary>
+    internal static class McpToolOutputShaper
+    {
+        /// <summary>
+        /// Shapes the body of a successful, non-empty response. On <c>false</c>,
+        /// <paramref name="failure"/> explains why in a sentence fit for the model to read.
+        /// </summary>
+        public static bool TryShape(
+            McpToolDescriptor tool,
+            McpToolInvocationResult result,
+            HttpContext context,
+            ILogger logger,
+            out JsonNode? shaped,
+            out string? failure)
+        {
+            shaped = null;
+            failure = null;
+            var output = tool.Output;
+            if (output == null)
+            {
+                shaped = null;
+                failure = "the tool declares no output shaping.";
+                return false;
+            }
+
+            var contentType = result.ContentType;
+            if (contentType != null && contentType.IndexOf("json", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                failure = "the response is '" + contentType + "', and only JSON responses can be shaped.";
+                return false;
+            }
+
+            JsonNode? node;
+            try
+            {
+                node = JsonNode.Parse(result.Body);
+            }
+            catch (JsonException)
+            {
+                failure = result.Truncated
+                    ? "the response body is not valid JSON because it exceeded the response size cap and was truncated."
+                    : "the response body is not valid JSON.";
+                return false;
+            }
+
+            if (node != null)
+            {
+                var include = BuildTree(output.IncludeFields);
+                if (include != null)
+                {
+                    ApplyInclude(node, include);
+                }
+
+                var exclude = BuildTree(output.ExcludeFields);
+                if (exclude != null)
+                {
+                    ApplyExclude(node, exclude);
+                }
+            }
+
+            if (output.ConverterType != null)
+            {
+                try
+                {
+                    var converter = ResolveConverter(output.ConverterType, context);
+                    node = converter.Convert(new McpToolOutputContext(tool, result, context), node);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "Nabu MCP output converter {Converter} failed for tool {Tool}.",
+                        output.ConverterType.FullName,
+                        tool.Name);
+                    failure = "the output converter '" + output.ConverterType.Name + "' failed with " + ex.GetType().Name + ".";
+                    return false;
+                }
+            }
+
+            shaped = node;
+            return true;
+        }
+
+        private static IMcpToolOutputConverter ResolveConverter(Type converterType, HttpContext context)
+        {
+            var registered = context.RequestServices.GetService(converterType);
+            if (registered != null)
+            {
+                return (IMcpToolOutputConverter)registered;
+            }
+
+            return (IMcpToolOutputConverter)ActivatorUtilities.CreateInstance(context.RequestServices, converterType);
+        }
+
+        /// <summary>One level of the field-path tree. A terminal node means "the whole subtree".</summary>
+        private sealed class PathNode
+        {
+            public readonly Dictionary<string, PathNode> Children =
+                new Dictionary<string, PathNode>(StringComparer.OrdinalIgnoreCase);
+
+            public bool IsTerminal;
+        }
+
+        private static PathNode? BuildTree(IReadOnlyList<string>? paths)
+        {
+            if (paths == null || paths.Count == 0)
+            {
+                return null;
+            }
+
+            var root = new PathNode();
+            foreach (var path in paths)
+            {
+                var current = root;
+                foreach (var segment in path.Split('.'))
+                {
+                    // "a" being terminal already covers "a.b"; don't grow a branch below it.
+                    if (current.IsTerminal)
+                    {
+                        break;
+                    }
+
+                    PathNode? child;
+                    if (!current.Children.TryGetValue(segment, out child))
+                    {
+                        child = new PathNode();
+                        current.Children[segment] = child;
+                    }
+
+                    current = child;
+                }
+
+                current.IsTerminal = true;
+            }
+
+            return root.Children.Count == 0 ? null : root;
+        }
+
+        /// <summary>
+        /// Keeps only the properties on a listed path. A terminal match keeps the whole subtree; a
+        /// non-terminal match keeps the property and recurses. Arrays are traversed transparently.
+        /// </summary>
+        private static void ApplyInclude(JsonNode node, PathNode tree)
+        {
+            var obj = node as JsonObject;
+            if (obj != null)
+            {
+                foreach (var name in SnapshotKeys(obj))
+                {
+                    PathNode? child;
+                    if (!tree.Children.TryGetValue(name, out child))
+                    {
+                        obj.Remove(name);
+                        continue;
+                    }
+
+                    if (!child.IsTerminal)
+                    {
+                        var value = obj[name];
+                        if (value != null)
+                        {
+                            ApplyInclude(value, child);
+                        }
+                    }
+                }
+
+                return;
+            }
+
+            var array = node as JsonArray;
+            if (array != null)
+            {
+                foreach (var element in array)
+                {
+                    if (element != null)
+                    {
+                        ApplyInclude(element, tree);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Removes the properties on a listed path. Arrays are traversed transparently.</summary>
+        private static void ApplyExclude(JsonNode node, PathNode tree)
+        {
+            var obj = node as JsonObject;
+            if (obj != null)
+            {
+                foreach (var name in SnapshotKeys(obj))
+                {
+                    PathNode? child;
+                    if (!tree.Children.TryGetValue(name, out child))
+                    {
+                        continue;
+                    }
+
+                    if (child.IsTerminal)
+                    {
+                        obj.Remove(name);
+                        continue;
+                    }
+
+                    var value = obj[name];
+                    if (value != null)
+                    {
+                        ApplyExclude(value, child);
+                    }
+                }
+
+                return;
+            }
+
+            var array = node as JsonArray;
+            if (array != null)
+            {
+                foreach (var element in array)
+                {
+                    if (element != null)
+                    {
+                        ApplyExclude(element, tree);
+                    }
+                }
+            }
+        }
+
+        private static List<string> SnapshotKeys(JsonObject obj)
+        {
+            // The property set is mutated while filtering, so iterate a copy of the names.
+            var names = new List<string>(obj.Count);
+            foreach (var pair in obj)
+            {
+                names.Add(pair.Key);
+            }
+
+            return names;
+        }
+    }
+}

--- a/src/Nabu.Mcp.AspNetCore/Server/McpRequestHandler.cs
+++ b/src/Nabu.Mcp.AspNetCore/Server/McpRequestHandler.cs
@@ -477,7 +477,7 @@ namespace Nabu.Mcp.AspNetCore.Server
                 return ToolError("The tool failed to execute: " + ex.Message);
             }
 
-            return BuildToolResult(tool!, result);
+            return BuildToolResult(tool!, result, context);
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace Nabu.Mcp.AspNetCore.Server
             return invoker;
         }
 
-        internal JsonObject BuildToolResult(McpToolDescriptor tool, McpToolInvocationResult result)
+        internal JsonObject BuildToolResult(McpToolDescriptor tool, McpToolInvocationResult result, HttpContext context)
         {
             var isError = _options.TreatErrorStatusAsToolError && !result.IsSuccess;
 
@@ -510,6 +510,28 @@ namespace Nabu.Mcp.AspNetCore.Server
             var isHttp = tool.HttpMethod.Length != 0;
 
             var text = result.Body;
+
+            // Output shaping applies to the success payload only: error bodies are the framework's
+            // failure text, not the entity the filters describe. It fails closed - a body that cannot
+            // be shaped is suppressed rather than exposed, because the shaping may exist to hide data.
+            JsonNode? shaped = null;
+            var isShaped = false;
+            if (tool.Output != null && !isError && !string.IsNullOrEmpty(text))
+            {
+                string? failure;
+                if (!McpToolOutputShaper.TryShape(tool, result, context, _logger, out shaped, out failure))
+                {
+                    _logger.LogWarning(
+                        "Nabu MCP suppressed the result of tool {Tool}: {Reason}",
+                        tool.Name,
+                        failure);
+                    return ToolError("The result of tool '" + tool.Name + "' was suppressed because " + failure);
+                }
+
+                isShaped = true;
+                text = shaped == null ? string.Empty : shaped.ToJsonString();
+            }
+
             if (string.IsNullOrEmpty(text))
             {
                 if (isHttp)
@@ -544,7 +566,7 @@ namespace Nabu.Mcp.AspNetCore.Server
 
             if (_options.IncludeStructuredContent && !isError && !result.Truncated)
             {
-                var structured = TryParseStructured(result);
+                var structured = isShaped ? WrapStructured(shaped) : TryParseStructured(result);
                 if (structured != null)
                 {
                     payload["structuredContent"] = structured;
@@ -552,6 +574,17 @@ namespace Nabu.Mcp.AspNetCore.Server
             }
 
             return payload;
+        }
+
+        /// <summary>structuredContent must be an object; wrap shaped arrays and scalars.</summary>
+        private static JsonNode? WrapStructured(JsonNode? shaped)
+        {
+            if (shaped is JsonObject)
+            {
+                return shaped;
+            }
+
+            return shaped == null ? null : new JsonObject { ["result"] = shaped };
         }
 
         private static JsonNode? TryParseStructured(McpToolInvocationResult result)

--- a/src/Nabu.Mcp.ModelContextProtocol/NabuOfficialMcpBridge.cs
+++ b/src/Nabu.Mcp.ModelContextProtocol/NabuOfficialMcpBridge.cs
@@ -110,7 +110,7 @@ namespace Nabu.Mcp.ModelContextProtocol
                 return Deserialize<CallToolResult>(NabuRequestHandler.ToolError("The tool failed to execute: " + ex.Message));
             }
 
-            return Deserialize<CallToolResult>(_handler.BuildToolResult(tool!, invocation));
+            return Deserialize<CallToolResult>(_handler.BuildToolResult(tool!, invocation, httpContext));
         }
 
         private HttpContext RequireHttpContext()

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Integration/OutputShapingTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Integration/OutputShapingTests.cs
@@ -1,0 +1,166 @@
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Integration
+{
+    /// <summary>
+    /// Drives the sample application's [McpToolOutput]-shaped tools end to end: the field filters,
+    /// the converter, the Tool-scoping that leaves sibling variants untouched, and the Minimal API
+    /// counterpart.
+    /// </summary>
+    [Collection(McpTestCollection.Name)]
+    public class OutputShapingTests
+    {
+        private readonly McpTestFixture _fixture;
+
+        public OutputShapingTests(McpTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Include_fields_narrow_the_response_to_the_listed_paths()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            await CreateTodoAsync("Shaping include check", token);
+
+            var result = await _fixture.CallToolAsync("todos_list_compact", new JsonObject(), token);
+
+            Assert.False(McpTestFixture.IsError(result));
+            var payload = McpTestFixture.JsonOf(result).AsObject();
+
+            // The page envelope keeps only totalCount and items; paging fields are gone.
+            Assert.True(payload.ContainsKey("totalCount"));
+            Assert.False(payload.ContainsKey("page"));
+            Assert.False(payload.ContainsKey("pageSize"));
+
+            var items = payload["items"]!.AsArray();
+            Assert.NotEmpty(items);
+            foreach (var item in items)
+            {
+                var obj = item!.AsObject();
+                Assert.True(obj.ContainsKey("id"));
+                Assert.True(obj.ContainsKey("title"));
+                Assert.True(obj.ContainsKey("isCompleted"));
+                Assert.False(obj.ContainsKey("owner"));
+                Assert.False(obj.ContainsKey("notes"));
+                Assert.False(obj.ContainsKey("attachments"));
+            }
+        }
+
+        [Fact]
+        public async Task Structured_content_is_shaped_too()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            await CreateTodoAsync("Shaping structured check", token);
+
+            var result = await _fixture.CallToolAsync("todos_list_compact", new JsonObject(), token);
+
+            var structured = result["structuredContent"]!.AsObject();
+            Assert.True(structured.ContainsKey("items"));
+            foreach (var item in structured["items"]!.AsArray())
+            {
+                Assert.False(item!.AsObject().ContainsKey("owner"));
+            }
+        }
+
+        [Fact]
+        public async Task Shaping_is_scoped_to_its_tool_and_leaves_sibling_variants_untouched()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            await CreateTodoAsync("Shaping scoping check", token);
+
+            var result = await _fixture.CallToolAsync("todos_list", new JsonObject(), token);
+
+            var items = McpTestFixture.JsonOf(result)["items"]!.AsArray();
+            Assert.NotEmpty(items);
+            Assert.True(items[0]!.AsObject().ContainsKey("owner"));
+        }
+
+        [Fact]
+        public async Task A_converter_transforms_the_filtered_response()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var created = await CreateTodoAsync("Converter check", token);
+            var id = created["id"]!.GetValue<string>();
+
+            var result = await _fixture.CallToolAsync("todos_get_summary", new JsonObject { ["id"] = id }, token);
+
+            Assert.False(McpTestFixture.IsError(result));
+            var payload = McpTestFixture.JsonOf(result).AsObject();
+
+            Assert.Equal(id, payload["id"]!.GetValue<string>());
+            Assert.Equal("[open] Converter check", payload["summary"]!.GetValue<string>());
+            Assert.False(payload.ContainsKey("owner"));
+            Assert.False(payload.ContainsKey("attachments"));
+
+            // The full-record sibling still answers everything.
+            var full = await _fixture.CallToolAsync("todos_get_by_id", new JsonObject { ["id"] = id }, token);
+            Assert.True(McpTestFixture.JsonOf(full).AsObject().ContainsKey("owner"));
+        }
+
+        [Fact]
+        public async Task Error_responses_are_not_shaped()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+
+            var result = await _fixture.CallToolAsync(
+                "todos_get_summary",
+                new JsonObject { ["id"] = "00000000-0000-0000-0000-000000000000" },
+                token);
+
+            // The 404 body passes through as the usual tool error, untouched by the converter.
+            Assert.True(McpTestFixture.IsError(result));
+            Assert.Contains("HTTP 404", McpTestFixture.TextOf(result));
+        }
+
+        [Fact]
+        public async Task Minimal_api_output_shaping_excludes_fields_per_tool()
+        {
+            var brief = await _fixture.CallToolAsync(
+                "server_time_in_zone_brief",
+                new JsonObject { ["timeZone"] = "UTC" });
+
+            var payload = McpTestFixture.JsonOf(brief).AsObject();
+            Assert.True(payload.ContainsKey("timeZone"));
+            Assert.True(payload.ContainsKey("now"));
+            Assert.False(payload.ContainsKey("utcOffset"));
+
+            var full = await _fixture.CallToolAsync(
+                "server_time_in_zone",
+                new JsonObject { ["timeZone"] = "UTC" });
+
+            Assert.True(McpTestFixture.JsonOf(full).AsObject().ContainsKey("utcOffset"));
+        }
+
+        [Fact]
+        public async Task Shaped_tools_are_advertised_like_any_other()
+        {
+            var token = await _fixture.GetTokenAsync("alice");
+            var envelope = await _fixture.RpcAsync("tools/list", token: token);
+            var tools = envelope["result"]!["tools"]!.AsArray();
+
+            var names = new System.Collections.Generic.List<string>();
+            foreach (var tool in tools)
+            {
+                names.Add(tool!["name"]!.GetValue<string>());
+            }
+
+            Assert.Contains("todos_list_compact", names);
+            Assert.Contains("todos_get_summary", names);
+            Assert.Contains("server_time_in_zone_brief", names);
+        }
+
+        private async Task<JsonObject> CreateTodoAsync(string title, System.Net.Http.Headers.AuthenticationHeaderValue token)
+        {
+            var created = await _fixture.CallToolAsync(
+                "todos_create",
+                new JsonObject { ["title"] = title },
+                token);
+
+            Assert.False(McpTestFixture.IsError(created));
+            return McpTestFixture.JsonOf(created).AsObject();
+        }
+    }
+}

--- a/tests/Nabu.Mcp.AspNetCore.Tests/Unit/McpToolOutputShaperTests.cs
+++ b/tests/Nabu.Mcp.AspNetCore.Tests/Unit/McpToolOutputShaperTests.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nabu.Mcp.AspNetCore.Discovery;
+using Nabu.Mcp.AspNetCore.Execution;
+using Xunit;
+
+namespace Nabu.Mcp.AspNetCore.Tests.Unit
+{
+    public class McpToolOutputShaperTests
+    {
+        [Fact]
+        public void Exclude_removes_nested_fields_and_traverses_arrays()
+        {
+            var shaped = Shape(
+                "{\"items\":[{\"id\":1,\"owner\":\"alice\",\"nested\":{\"secret\":true,\"keep\":1}}]," +
+                "\"owner\":\"root\",\"totalCount\":1}",
+                excludeFields: new[] { "items.owner", "items.nested.secret", "owner" });
+
+            var root = shaped!.AsObject();
+            Assert.Null(root["owner"]);
+            Assert.Equal(1, root["totalCount"]!.GetValue<int>());
+
+            var item = root["items"]!.AsArray()[0]!.AsObject();
+            Assert.Equal(1, item["id"]!.GetValue<int>());
+            Assert.Null(item["owner"]);
+            Assert.Null(item["nested"]!["secret"]);
+            Assert.Equal(1, item["nested"]!["keep"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public void Include_keeps_only_listed_paths()
+        {
+            var shaped = Shape(
+                "{\"items\":[{\"id\":1,\"title\":\"a\",\"owner\":\"alice\"}],\"totalCount\":1,\"page\":0}",
+                includeFields: new[] { "items.id", "items.title", "totalCount" });
+
+            var root = shaped!.AsObject();
+            Assert.Null(root["page"]);
+            Assert.Equal(1, root["totalCount"]!.GetValue<int>());
+
+            var item = root["items"]!.AsArray()[0]!.AsObject();
+            Assert.Equal("a", item["title"]!.GetValue<string>());
+            Assert.Null(item["owner"]);
+        }
+
+        [Fact]
+        public void Include_terminal_path_keeps_whole_subtree()
+        {
+            var shaped = Shape(
+                "{\"data\":{\"a\":1,\"b\":{\"c\":2}},\"extra\":true}",
+                includeFields: new[] { "data" });
+
+            var root = shaped!.AsObject();
+            Assert.Null(root["extra"]);
+            Assert.Equal(2, root["data"]!["b"]!["c"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public void Field_matching_is_case_insensitive()
+        {
+            var shaped = Shape(
+                "{\"Items\":[{\"Owner\":\"alice\",\"Id\":1}]}",
+                excludeFields: new[] { "items.owner" });
+
+            var item = shaped!["Items"]!.AsArray()[0]!.AsObject();
+            Assert.Null(item["Owner"]);
+            Assert.Equal(1, item["Id"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public void Exclude_applies_after_include()
+        {
+            var shaped = Shape(
+                "{\"item\":{\"id\":1,\"title\":\"a\",\"owner\":\"alice\"},\"extra\":true}",
+                includeFields: new[] { "item" },
+                excludeFields: new[] { "item.owner" });
+
+            var root = shaped!.AsObject();
+            Assert.Null(root["extra"]);
+            Assert.Null(root["item"]!["owner"]);
+            Assert.Equal("a", root["item"]!["title"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Unknown_paths_change_nothing()
+        {
+            var shaped = Shape("{\"a\":1}", excludeFields: new[] { "does.not.exist" });
+            Assert.Equal(1, shaped!["a"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public void Array_root_is_traversed()
+        {
+            var shaped = Shape("[{\"id\":1,\"owner\":\"alice\"}]", excludeFields: new[] { "owner" });
+            var item = shaped!.AsArray()[0]!.AsObject();
+            Assert.Null(item["owner"]);
+            Assert.Equal(1, item["id"]!.GetValue<int>());
+        }
+
+        [Fact]
+        public void Non_json_content_type_fails_closed()
+        {
+            var failure = ShapeFailure("<xml/>", contentType: "application/xml", excludeFields: new[] { "a" });
+            Assert.Contains("only JSON", failure);
+        }
+
+        [Fact]
+        public void Invalid_json_body_fails_closed()
+        {
+            var failure = ShapeFailure("{\"a\":", contentType: "application/json", excludeFields: new[] { "a" });
+            Assert.Contains("not valid JSON", failure);
+        }
+
+        [Fact]
+        public void Converter_receives_filtered_output_and_replaces_it()
+        {
+            var shaped = Shape(
+                "{\"title\":\"a\",\"owner\":\"alice\"}",
+                excludeFields: new[] { "owner" },
+                converterType: typeof(RecordingConverter));
+
+            Assert.Equal("a", shaped!["seenTitle"]!.GetValue<string>());
+            Assert.False(shaped["sawOwner"]!.GetValue<bool>());
+        }
+
+        [Fact]
+        public void Converter_is_resolved_from_services_when_registered()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new ConverterDependency { Marker = "from-di" });
+            services.AddSingleton<DependentConverter>();
+
+            var shaped = Shape(
+                "{}",
+                converterType: typeof(DependentConverter),
+                provider: services.BuildServiceProvider());
+
+            Assert.Equal("from-di", shaped!["marker"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Converter_dependencies_are_activated_when_not_registered()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new ConverterDependency { Marker = "activated" });
+
+            var shaped = Shape(
+                "{}",
+                converterType: typeof(DependentConverter),
+                provider: services.BuildServiceProvider());
+
+            Assert.Equal("activated", shaped!["marker"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Throwing_converter_fails_closed()
+        {
+            var failure = ShapeFailure(
+                "{\"secret\":true}",
+                contentType: "application/json",
+                converterType: typeof(ThrowingConverter));
+
+            Assert.Contains("ThrowingConverter", failure);
+            Assert.DoesNotContain("secret", failure);
+        }
+
+        private static JsonNode? Shape(
+            string body,
+            string[]? includeFields = null,
+            string[]? excludeFields = null,
+            Type? converterType = null,
+            IServiceProvider? provider = null)
+        {
+            JsonNode? shaped;
+            string? failure;
+            var ok = TryShape(body, "application/json", includeFields, excludeFields, converterType, provider, out shaped, out failure);
+            Assert.True(ok, "Shaping unexpectedly failed: " + failure);
+            return shaped;
+        }
+
+        private static string ShapeFailure(
+            string body,
+            string contentType,
+            string[]? includeFields = null,
+            string[]? excludeFields = null,
+            Type? converterType = null)
+        {
+            JsonNode? shaped;
+            string? failure;
+            var ok = TryShape(body, contentType, includeFields, excludeFields, converterType, null, out shaped, out failure);
+            Assert.False(ok, "Shaping unexpectedly succeeded.");
+            return failure!;
+        }
+
+        private static bool TryShape(
+            string body,
+            string? contentType,
+            string[]? includeFields,
+            string[]? excludeFields,
+            Type? converterType,
+            IServiceProvider? provider,
+            out JsonNode? shaped,
+            out string? failure)
+        {
+            var tool = new McpToolDescriptor(
+                "test_tool",
+                new List<McpToolParameterDescriptor>(),
+                new JsonObject(),
+                new McpToolAnnotations())
+            {
+                Output = new McpToolOutputDescriptor(includeFields, excludeFields, converterType),
+            };
+
+            var result = new McpToolInvocationResult(200, contentType, body, new Dictionary<string, string>());
+            var context = new DefaultHttpContext
+            {
+                RequestServices = provider ?? new ServiceCollection().BuildServiceProvider(),
+            };
+
+            return McpToolOutputShaper.TryShape(tool, result, context, NullLogger.Instance, out shaped, out failure);
+        }
+
+        private sealed class RecordingConverter : IMcpToolOutputConverter
+        {
+            public JsonNode? Convert(McpToolOutputContext context, JsonNode? output)
+            {
+                var obj = output!.AsObject();
+                return new JsonObject
+                {
+                    ["seenTitle"] = obj["title"]!.GetValue<string>(),
+                    ["sawOwner"] = obj["owner"] != null,
+                };
+            }
+        }
+
+        private sealed class ConverterDependency
+        {
+            public string Marker { get; set; } = string.Empty;
+        }
+
+        private sealed class DependentConverter : IMcpToolOutputConverter
+        {
+            private readonly ConverterDependency _dependency;
+
+            public DependentConverter(ConverterDependency dependency)
+            {
+                _dependency = dependency;
+            }
+
+            public JsonNode? Convert(McpToolOutputContext context, JsonNode? output)
+            {
+                return new JsonObject { ["marker"] = _dependency.Marker };
+            }
+        }
+
+        private sealed class ThrowingConverter : IMcpToolOutputConverter
+        {
+            public JsonNode? Convert(McpToolOutputContext context, JsonNode? output)
+            {
+                throw new InvalidOperationException("the secret is 42");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `[McpToolOutput]` attribute and supporting infrastructure to shape JSON responses before they're exposed to MCP clients. This allows actions to keep their full HTTP API contract while selectively hiding fields or transforming responses for the model.

## Key Changes

- **New `[McpToolOutput]` attribute** (`McpToolOutputAttribute.cs`): Declarative control over tool output with:
  - `IncludeFields`: Keep only specified dot-separated field paths
  - `ExcludeFields`: Remove specified field paths (applied after include)
  - `Converter`: Optional `IMcpToolOutputConverter` type to transform the filtered JSON
  - `Tool`: Scope to specific tool when an action publishes multiple tools
  - Repeatable at class and method level with precedence rules (method > class, scoped > unscoped)

- **Output shaping engine** (`McpToolOutputShaper.cs`): 
  - Parses response JSON and applies field filters via tree-based path matching
  - Case-insensitive field matching with transparent array traversal
  - Converter resolution from DI or activation via `ActivatorUtilities`
  - Fail-closed design: shaping failures suppress the response rather than leaking unshaped data

- **Converter interface** (`IMcpToolOutputConverter.cs`): Allows custom transformation of filtered JSON before exposure to clients

- **Discovery and resolution** (`McpToolOutputResolver.cs`, `McpToolOutputDescriptor.cs`):
  - Validates converter types during tool discovery
  - Normalizes and validates field paths
  - Warns on misconfigured tool-scoped attributes

- **Integration points**:
  - Controller actions via `[McpToolOutput]` attribute
  - Minimal APIs via `.McpToolOutput()` endpoint convention
  - SignalR hubs via `[McpToolOutput]` attribute
  - Output shaping applied in `McpRequestHandler.BuildToolResult()`

- **Comprehensive test coverage**:
  - Unit tests for field filtering, array traversal, include/exclude logic, converters
  - Integration tests demonstrating end-to-end shaping with multi-tool actions and converters
  - Sample implementation (`TodoSummaryOutputConverter`) showing converter usage

## Notable Implementation Details

- Field paths use case-insensitive matching against JSON property names
- Arrays are traversed transparently: a path segment applies to all array elements
- Shaping only applies to successful (non-error) responses with JSON content
- Converters receive already-filtered JSON and may mutate or replace it entirely
- Exceptions in converters are logged and treated as tool errors (fail-closed)
- Tool-scoped occurrences allow different output shapes for variants of the same action

https://claude.ai/code/session_01G29RV3YnPfw2fVqNbhdvXu